### PR TITLE
Add CREATE stmt generators for functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,5 +1,5 @@
 [[package]]
-name = "add-one"
+name = "adding"
 version = "0.1.0"
 dependencies = [
  "pg-extend 0.2.1",

--- a/README.md
+++ b/README.md
@@ -28,5 +28,9 @@ This informs the linker that some of the symbols for postgres won't be available
 
 ## Examples
 
-- [add_one](https://github.com/bluejekyll/pg-extend-rs/tree/master/examples/add_one)
+- [adding](https://github.com/bluejekyll/pg-extend-rs/tree/master/examples/adding)
 - [panicking](https://github.com/bluejekyll/pg-extend-rs/tree/master/examples/panicking)
+
+## Features
+
+To use the postgres allocator, the feature `pg_allocator` must be defined and enabled in the implementing crate.

--- a/examples/add_one/Cargo.toml
+++ b/examples/add_one/Cargo.toml
@@ -1,11 +1,18 @@
 [package]
-name = "add-one"
+name = "adding"
 version = "0.1.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
 edition = "2018"
 
+[features]
+pg_allocator = []
+
 [lib]
 crate-type = ["cdylib"]
+
+[[bin]]
+name = "adding-stmt"
+path = "src/bin.rs"
 
 [dependencies]
 pg-extern-attr = { version = "*", path = "../../pg-extern-attr" }

--- a/examples/add_one/README.md
+++ b/examples/add_one/README.md
@@ -13,5 +13,5 @@ then load into postgres
 
 ```console
 $> psql $CONN_STR
-postgres=# CREATE FUNCTION add_one(integer) RETURNS integer AS 'path/to/crate/target/release/libadd_one.dylib', 'pg_add_one' LANGUAGE C STRICT;
+postgres=# CREATE FUNCTION add_one(integer) RETURNS integer AS 'path/to/crate/target/release/libadding.dylib', 'pg_add_one' LANGUAGE C STRICT;
 ```

--- a/examples/add_one/src/bin.rs
+++ b/examples/add_one/src/bin.rs
@@ -1,0 +1,18 @@
+// becuase the lib is a cdylib... maybe there's a better way?
+#[cfg(not(feature = "pg_allocator"))]
+mod lib;
+
+#[cfg(not(feature = "pg_allocator"))]
+fn main() {
+    const LIB_NAME: &'static str = env!("CARGO_PKG_NAME");
+    
+    println!("{}", lib::add_one_pg_create_stmt(&format!("target/release/lib{}.dylib", LIB_NAME)));
+    println!("{}", lib::add_small_one_pg_create_stmt(&format!("target/release/lib{}.dylib", LIB_NAME)));
+    println!("{}", lib::add_big_one_pg_create_stmt(&format!("target/release/lib{}.dylib", LIB_NAME)));
+    println!("{}", lib::add_together_pg_create_stmt(&format!("target/release/lib{}.dylib", LIB_NAME)));
+}
+
+#[cfg(feature = "pg_allocator")]
+fn main() {
+    println!("disable `pg_allocator` feature to print create STMTs")
+}

--- a/examples/add_one/src/lib.rs
+++ b/examples/add_one/src/lib.rs
@@ -17,12 +17,27 @@ pg_magic!(version: pg_sys::PG_VERSION_NUM);
 /// The pg_extern attribute wraps the function in the proper functions syntax for C extensions
 #[pg_extern]
 fn add_one(value: i32) -> i32 {
-    // test allocation...
-    let msg: String = format!("fun: {}", value);
-    println!("more: {}", msg);
-
     (value + 1)
 }
+
+/// Test the i16 value
+#[pg_extern]
+fn add_small_one(value: i16) -> i16 {
+    (value + 1)
+}
+
+/// Test the i16 value
+#[pg_extern]
+fn add_big_one(value: i64) -> i64 {
+    (value + 1)
+}
+
+/// Test the i16 value
+#[pg_extern]
+fn add_together(v1: i64, v2: i32, v3: i16) -> i64 {
+    (v1 + v2 as i64 + v3 as i64)
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/examples/panicking/Cargo.toml
+++ b/examples/panicking/Cargo.toml
@@ -4,8 +4,15 @@ version = "0.1.0"
 authors = ["Benjamin Fry <benjaminfry@me.com>"]
 edition = "2018"
 
+[features]
+pg_allocator = []
+
 [lib]
 crate-type = ["cdylib"]
+
+[[bin]]
+name = "panicking-stmt"
+path = "src/bin.rs"
 
 [dependencies]
 pg-extern-attr = { version = "*", path = "../../pg-extern-attr" }

--- a/examples/panicking/src/bin.rs
+++ b/examples/panicking/src/bin.rs
@@ -1,0 +1,15 @@
+// becuase the lib is a cdylib... maybe there's a better way?
+#[cfg(not(feature = "pg_allocator"))]
+mod lib;
+
+#[cfg(not(feature = "pg_allocator"))]
+fn main() {
+    const LIB_NAME: &'static str = env!("CARGO_PKG_NAME");
+
+    println!("{}", lib::panicking_pg_create_stmt(&format!("target/release/lib{}.dylib", LIB_NAME)));
+}
+
+#[cfg(feature = "pg_allocator")]
+fn main() {
+    println!("disable `pg_allocator` feature to print create STMTs")
+}

--- a/examples/panicking/src/lib.rs
+++ b/examples/panicking/src/lib.rs
@@ -9,7 +9,7 @@ extern crate pg_extern_attr;
 extern crate pg_extend;
 
 use pg_extern_attr::pg_extern;
-use pg_extend::{pg_sys, pg_magic};
+use pg_extend::pg_magic;
 
 /// This tells Postges this library is a Postgres extension
 pg_magic!(version: pg_sys::PG_VERSION_NUM);
@@ -25,7 +25,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_add_one() {
-        assert_eq!(add_one(1), 2);
+    #[should_panic]
+    fn test_panicking() {
+        assert_eq!(panicking(1), 2);
     }
 }

--- a/pg-extend/src/lib.rs
+++ b/pg-extend/src/lib.rs
@@ -17,6 +17,7 @@ pub mod pg_bool;
 pub mod pg_datum;
 pub mod pg_error;
 pub mod pg_sys;
+pub mod pg_type;
 
 /// A macro for marking a library compatible with the Postgres extension framework.
 /// 
@@ -27,6 +28,7 @@ macro_rules! pg_magic {
         // Set the global allocator to use postgres' allocator, which guarantees all memory freed at
         //   transaction close.
         #[global_allocator]
+        #[cfg(feature = "pg_allocator")]
         static GLOBAL: pg_extend::pg_alloc::PgAllocator = pg_extend::pg_alloc::PgAllocator;
 
         #[no_mangle]

--- a/pg-extend/src/pg_datum.rs
+++ b/pg-extend/src/pg_datum.rs
@@ -56,6 +56,22 @@ pub trait TryFromPgDatum: Sized {
     fn try_from(datum: PgDatum) -> Result<Self, &'static str>;
 }
 
+impl TryFromPgDatum for i16 {
+    fn try_from(datum: PgDatum) -> Result<Self, &'static str> {
+        if let Some(datum) = datum.0 {
+            Ok(datum as i16)
+        } else {
+            Err("datum was NULL")
+        }
+    }
+}
+
+impl From<i16> for PgDatum {
+    fn from(value: i16) -> Self {
+        PgDatum(Some(value as Datum))
+    }
+}
+
 impl TryFromPgDatum for i32 {
     fn try_from(datum: PgDatum) -> Result<Self, &'static str> {
         if let Some(datum) = datum.0 {
@@ -68,6 +84,24 @@ impl TryFromPgDatum for i32 {
 
 impl From<i32> for PgDatum {
     fn from(value: i32) -> Self {
+        PgDatum(Some(value as Datum))
+    }
+}
+
+impl TryFromPgDatum for i64 {
+    fn try_from(datum: PgDatum) -> Result<Self, &'static str> {
+        assert!(std::mem::size_of::<Datum>() >= std::mem::size_of::<i64>(), "Datum not large enough for i64 values");
+        if let Some(datum) = datum.0 {
+            Ok(datum as i64)
+        } else {
+            Err("datum was NULL")
+        }
+    }
+}
+
+impl From<i64> for PgDatum {
+    fn from(value: i64) -> Self {
+        assert!(std::mem::size_of::<Datum>() >= std::mem::size_of::<i64>(), "Datum not large enough for i64 values");
         PgDatum(Some(value as Datum))
     }
 }

--- a/pg-extend/src/pg_type.rs
+++ b/pg-extend/src/pg_type.rs
@@ -1,0 +1,204 @@
+//! Postgres type definitions
+
+/// See https://www.postgresql.org/docs/11/xfunc-c.html#XFUNC-C-TYPE-TABLE
+///
+/// TODO: it would be cool to share code with the sfackler/rust-postgres project
+/// though, that is converting from NetworkByte order, and this is all NativeByte order?
+#[derive(Clone, Copy)]
+pub enum PgType {
+    /// NULL, not a PG type, this may be removed in the future
+    Null,
+    /// abstime 	AbsoluteTime 	utils/nabstime.h
+    AbsoluteTime,
+    /// bigint (int8) 	int64 	postgres.h
+    BigInt,
+    /// bigint (int8) 	int64 	postgres.h
+    Int8,
+    /// boolean 	bool 	postgres.h (maybe compiler built-in)
+    Boolean,
+    /// box 	BOX* 	utils/geo_decls.h
+    GeoBox,
+    /// bytea 	bytea* 	postgres.h
+    ByteA,
+    /// "char" 	char 	(compiler built-in)
+    Char,
+    /// character 	BpChar* 	postgres.h
+    Character,
+    /// cid 	CommandId 	postgres.h
+    CommandId,
+    /// date 	DateADT 	utils/date.h
+    Date,
+    /// smallint (int2) 	int16 	postgres.h
+    SmallInt,
+    /// smallint (int2) 	int16 	postgres.h
+    Int2,
+    /// int2vector 	int2vector* 	postgres.h
+    Int2Vector,
+    /// integer (int4) 	int32 	postgres.h
+    Integer,
+    /// integer (int4) 	int32 	postgres.h
+    Int4,
+    /// real (float4) 	float4* 	postgres.h
+    Real,
+    /// real (float4) 	float4* 	postgres.h
+    Float4,
+    /// double precision (float8) 	float8* 	postgres.h
+    DoublePrecision,
+    /// double precision (float8) 	float8* 	postgres.h
+    Float8,
+    /// interval 	Interval* 	datatype/timestamp.h
+    Interval,
+    /// lseg 	LSEG* 	utils/geo_decls.h
+    Lseg,
+    /// name 	Name 	postgres.h
+    Name,
+    /// oid 	Oid 	postgres.h
+    Oid,
+    /// oidvector 	oidvector* 	postgres.h
+    OidVector,
+    /// path 	PATH* 	utils/geo_decls.h
+    Path,
+    /// point 	POINT* 	utils/geo_decls.h
+    Point,
+    /// regproc 	regproc 	postgres.h
+    RegProc,
+    /// reltime 	RelativeTime 	utils/nabstime.h
+    RelativeTime,
+    /// text 	text* 	postgres.h
+    Text,
+    /// tid 	ItemPointer 	storage/itemptr.h
+    ItemPointer,
+    /// time 	TimeADT 	utils/date.h
+    Time,
+    /// time with time zone 	TimeTzADT 	utils/date.h
+    TimeWithTimeZone,
+    /// timestamp 	Timestamp* 	datatype/timestamp.h
+    Timestamp,
+    /// tinterval 	TimeInterval 	utils/nabstime.h
+    TimeInterval,
+    /// varchar 	VarChar* 	postgres.h
+    VarChar,
+    /// xid 	TransactionId 	postgres.h
+    TransactionId,
+}
+
+impl PgType {
+    /// Return the PgType of the parameter's type
+    pub fn from_rust<T: PgTypeInfo>() -> PgType {
+        T::pg_type()
+    }
+
+    /// Return the string representation of this type
+    pub fn as_str(&self) -> &'static str {
+        match *self {
+            // NULL
+            // TODO: this might be incorrect, and may go away
+            PgType::Null => "NULL",
+            // abstime 	AbsoluteTime 	utils/nabstime.h
+            PgType::AbsoluteTime => "abstime",
+            // bigint (int8) 	int64 	postgres.h
+            PgType::BigInt => "bigint",
+            PgType::Int8 => "int8",
+            // boolean 	bool 	postgres.h (maybe compiler built-in)
+            PgType::Boolean => "boolean",
+            // box 	BOX* 	utils/geo_decls.h
+            PgType::GeoBox => "box",
+            // bytea 	bytea* 	postgres.h
+            PgType::ByteA => "bytea",
+            // "char" 	char 	(compiler built-in)
+            PgType::Char => "char",
+            // character 	BpChar* 	postgres.h
+            PgType::Character => "character",
+            // cid 	CommandId 	postgres.h
+            PgType::CommandId => "cid",
+            // date 	DateADT 	utils/date.h
+            PgType::Date => "date",
+            // smallint (int2) 	int16 	postgres.h
+            PgType::SmallInt => "smallint",
+            PgType::Int2 => "int2",
+            // int2vector 	int2vector* 	postgres.h
+            PgType::Int2Vector => "int2vector",
+            // integer (int4) 	int32 	postgres.h
+            PgType::Integer => "integer",
+            PgType::Int4 => "int4",
+            // real (float4) 	float4* 	postgres.h
+            PgType::Real => "real",
+            PgType::Float4 => "float4",
+            // double precision (float8) 	float8* 	postgres.h
+            PgType::DoublePrecision => "double precision",
+            PgType::Float8 => "float8",
+            // interval 	Interval* 	datatype/timestamp.h
+            PgType::Interval => "interval",
+            // lseg 	LSEG* 	utils/geo_decls.h
+            PgType::Lseg => "lseg",
+            // name 	Name 	postgres.h
+            PgType::Name => "name",
+            // oid 	Oid 	postgres.h
+            PgType::Oid => "oid",
+            // oidvector 	oidvector* 	postgres.h
+            PgType::OidVector => "oidvector",
+            // path 	PATH* 	utils/geo_decls.h
+            PgType::Path => "path",
+            // point 	POINT* 	utils/geo_decls.h
+            PgType::Point => "point",
+            // regproc 	regproc 	postgres.h
+            PgType::RegProc => "regproc",
+            // reltime 	RelativeTime 	utils/nabstime.h
+            PgType::RelativeTime => "reltime",
+            // text 	text* 	postgres.h
+            PgType::Text => "text",
+            // tid 	ItemPointer 	storage/itemptr.h
+            PgType::ItemPointer => "tid",
+            // time 	TimeADT 	utils/date.h
+            PgType::Time => "time",
+            // time with time zone 	TimeTzADT 	utils/date.h
+            PgType::TimeWithTimeZone => "time with time zone",
+            // timestamp 	Timestamp* 	datatype/timestamp.h
+            PgType::Timestamp => "timestamp",
+            // tinterval 	TimeInterval 	utils/nabstime.h
+            PgType::TimeInterval => "tinterval",
+            // varchar 	VarChar* 	postgres.h
+            PgType::VarChar => "varchar",
+            // xid 	TransactionId 	postgres.h
+            PgType::TransactionId => "xid",
+        }
+    }
+
+    /// Return the String to be used for the RETURNS statement in SQL
+    pub fn return_stmt(&self) -> String {
+        match self {
+            PgType::Null => String::new(),
+            ty => format!("RETURNS {}", ty.as_str()),
+        }
+    }
+}
+
+/// Get the Postgres info for a type
+pub trait PgTypeInfo {
+    /// return the Postgres type
+    fn pg_type() -> PgType;
+}
+
+impl PgTypeInfo for i16 {
+    fn pg_type() -> PgType {
+        PgType::Int2
+    }
+}
+
+impl PgTypeInfo for i32 {
+    fn pg_type() -> PgType {
+        PgType::Int4
+    }
+}
+
+impl PgTypeInfo for i64 {
+    fn pg_type() -> PgType {
+        PgType::Int8
+    }
+}
+
+impl PgTypeInfo for () {
+    fn pg_type() -> PgType {
+        PgType::Null
+    }
+}


### PR DESCRIPTION
This adds support for outputting `create function` generators for the associated functions in Postgres. It should make testing easier.