### PR TITLE
Run bindgen conditionally

### DIFF
--- a/pg-extend/build.rs
+++ b/pg-extend/build.rs
@@ -11,34 +11,39 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    let pg_include = env::var("PG_INCLUDE_PATH").expect("set environment variable PG_INCLUDE_PATH to the Postgres install include dir, e.g. /var/lib/pgsql/include/server");
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap())
+        .join("postgres.rs");
 
-    // println!("cargo:rustc-link-search=/Users/benjaminfry/Downloads/postgresql-11.1/src/common");
-    // println!("cargo:rustc-link-lib=pgcommon_srv");
+    if !out_path.exists() {
+        let pg_include = env::var("PG_INCLUDE_PATH")
+            .expect("set environment variable PG_INCLUDE_PATH to the Postgres install include dir, e.g. /var/lib/pgsql/include/server");
 
-    // pkg_config::Config::new().atleast_version("11.1").probe("libpq").unwrap();
-    // pkg_config::Config::new().atleast_version("11.1").probe("libecpg").unwrap();
+        // println!("cargo:rustc-link-search=/Users/benjaminfry/Downloads/postgresql-11.1/src/common");
+        // println!("cargo:rustc-link-lib=pgcommon_srv");
 
-    // The bindgen::Builder is the main entry point
-    // to bindgen, and lets you build up options for
-    // the resulting bindings.
-    let bindings = bindgen::Builder::default()
-        .clang_arg(format!("-I{}",pg_include))
-        // The input header we would like to generate
-        // bindings for.
-        .header("wrapper.h")
-        .rustfmt_bindings(true)
-        // FIXME: add this back
-        .layout_tests(false);
-    
-        // Finish the builder and generate the bindings.
-    let bindings = bindings.generate()
-        // Unwrap the Result and panic on failure.
-        .expect("Unable to generate bindings");
+        // pkg_config::Config::new().atleast_version("11.1").probe("libpq").unwrap();
+        // pkg_config::Config::new().atleast_version("11.1").probe("libecpg").unwrap();
 
-    // Write the bindings to the $OUT_DIR/bindings.rs file.
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    bindings
-        .write_to_file(out_path.join("postgres.rs"))
-        .expect("Couldn't write bindings!");
+        // The bindgen::Builder is the main entry point
+        // to bindgen, and lets you build up options for
+        // the resulting bindings.
+        let bindings = bindgen::Builder::default()
+            .clang_arg(format!("-I{}",pg_include))
+            // The input header we would like to generate
+            // bindings for.
+            .header("wrapper.h")
+            .rustfmt_bindings(true)
+            // FIXME: add this back
+            .layout_tests(false);
+
+            // Finish the builder and generate the bindings.
+        let bindings = bindings.generate()
+            // Unwrap the Result and panic on failure.
+            .expect("Unable to generate bindings");
+
+        // Write the bindings to the $OUT_DIR/postgres.rs file.
+        bindings
+            .write_to_file(out_path)
+            .expect("Couldn't write bindings!");
+    }
 }


### PR DESCRIPTION
This has a few benefits:
* Faster compile times
* After the first compile, the PG_INCLUDE_PATH isn't required
(which helps with IDE integration)

also, right now I need to massage my output file a  bit, and this prevents having to do this every time 😅 