### PR TITLE
From<String> for PgDatum and back

### DIFF
--- a/pg-extend/Cargo.toml
+++ b/pg-extend/Cargo.toml
@@ -18,8 +18,10 @@ build = "build.rs"
 #rustc-flags = "-C link-arg=undefineddynamic_lookup"
 
 [features]
-default = []
-postgres9 = []
+default = ["postgres-10"]
+postgres-9 = []
+postgres-10 = []
+postgres-11 = []
 
 [dependencies]
 

--- a/pg-extend/build.rs
+++ b/pg-extend/build.rs
@@ -14,56 +14,57 @@ use std::path::PathBuf;
 fn main() {
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("postgres.rs");
 
-    if !out_path.exists() {
-        let pg_include = env::var("PG_INCLUDE_PATH")
-            .expect("set environment variable PG_INCLUDE_PATH to the Postgres install include dir, e.g. /var/lib/pgsql/include/server");
+    // Re-run this if wrapper.h changes
+    println!("cargo:rerun-if-changed=wrapper.h");
 
-        // println!("cargo:rustc-link-search=/Users/benjaminfry/Downloads/postgresql-11.1/src/common");
-        // println!("cargo:rustc-link-lib=pgcommon_srv");
+    let pg_include = env::var("PG_INCLUDE_PATH")
+        .expect("set environment variable PG_INCLUDE_PATH to the Postgres install include dir, e.g. /var/lib/pgsql/include/server");
 
-        // pkg_config::Config::new().atleast_version("11.1").probe("libpq").unwrap();
-        // pkg_config::Config::new().atleast_version("11.1").probe("libecpg").unwrap();
+    // println!("cargo:rustc-link-search=/Users/benjaminfry/Downloads/postgresql-11.1/src/common");
+    // println!("cargo:rustc-link-lib=pgcommon_srv");
 
-        // The bindgen::Builder is the main entry point
-        // to bindgen, and lets you build up options for
-        // the resulting bindings.
+    // pkg_config::Config::new().atleast_version("11.1").probe("libpq").unwrap();
+    // pkg_config::Config::new().atleast_version("11.1").probe("libecpg").unwrap();
 
-        // these cause duplicate definition problems on linux
-        // see: https://github.com/rust-lang/rust-bindgen/issues/687
-        let ignored_macros = IgnoreMacros(
-            vec![
-                "FP_INFINITE".into(),
-                "FP_NAN".into(),
-                "FP_NORMAL".into(),
-                "FP_SUBNORMAL".into(),
-                "FP_ZERO".into(),
-                "IPPORT_RESERVED".into(),
-            ]
-            .into_iter()
-            .collect(),
-        );
+    // The bindgen::Builder is the main entry point
+    // to bindgen, and lets you build up options for
+    // the resulting bindings.
 
-        let bindings = bindgen::Builder::default()
-            .clang_arg(format!("-I{}", pg_include))
-            // The input header we would like to generate
-            // bindings for.
-            .header("wrapper.h")
-            .parse_callbacks(Box::new(ignored_macros))
-            .rustfmt_bindings(true)
-            // FIXME: add this back
-            .layout_tests(false);
+    // these cause duplicate definition problems on linux
+    // see: https://github.com/rust-lang/rust-bindgen/issues/687
+    let ignored_macros = IgnoreMacros(
+        vec![
+            "FP_INFINITE".into(),
+            "FP_NAN".into(),
+            "FP_NORMAL".into(),
+            "FP_SUBNORMAL".into(),
+            "FP_ZERO".into(),
+            "IPPORT_RESERVED".into(),
+        ]
+        .into_iter()
+        .collect(),
+    );
 
-        // Finish the builder and generate the bindings.
-        let bindings = bindings
-            .generate()
-            // Unwrap the Result and panic on failure.
-            .expect("Unable to generate bindings");
+    let bindings = bindgen::Builder::default()
+        .clang_arg(format!("-I{}", pg_include))
+        // The input header we would like to generate
+        // bindings for.
+        .header("wrapper.h")
+        .parse_callbacks(Box::new(ignored_macros))
+        .rustfmt_bindings(true)
+        // FIXME: add this back
+        .layout_tests(false);
 
-        // Write the bindings to the $OUT_DIR/postgres.rs file.
-        bindings
-            .write_to_file(out_path)
-            .expect("Couldn't write bindings!");
-    }
+    // Finish the builder and generate the bindings.
+    let bindings = bindings
+        .generate()
+        // Unwrap the Result and panic on failure.
+        .expect("Unable to generate bindings");
+
+    // Write the bindings to the $OUT_DIR/postgres.rs file.
+    bindings
+        .write_to_file(out_path)
+        .expect("Couldn't write bindings!");
 }
 
 #[derive(Debug)]

--- a/pg-extend/build.rs
+++ b/pg-extend/build.rs
@@ -20,16 +20,6 @@ fn main() {
     let pg_include = env::var("PG_INCLUDE_PATH")
         .expect("set environment variable PG_INCLUDE_PATH to the Postgres install include dir, e.g. /var/lib/pgsql/include/server");
 
-    // println!("cargo:rustc-link-search=/Users/benjaminfry/Downloads/postgresql-11.1/src/common");
-    // println!("cargo:rustc-link-lib=pgcommon_srv");
-
-    // pkg_config::Config::new().atleast_version("11.1").probe("libpq").unwrap();
-    // pkg_config::Config::new().atleast_version("11.1").probe("libecpg").unwrap();
-
-    // The bindgen::Builder is the main entry point
-    // to bindgen, and lets you build up options for
-    // the resulting bindings.
-
     // these cause duplicate definition problems on linux
     // see: https://github.com/rust-lang/rust-bindgen/issues/687
     let ignored_macros = IgnoreMacros(

--- a/pg-extend/src/lib.rs
+++ b/pg-extend/src/lib.rs
@@ -65,10 +65,10 @@ pub fn get_args<'a>(
 ) -> (impl 'a + Iterator<Item=&pg_sys::Datum>, impl 'a + Iterator<Item=pg_bool::Bool>) {
     let num_args = func_call_info.nargs as usize;
 
-    let args = func_call_info.arg[..num_args].into_iter();
+    let args = func_call_info.arg[..num_args].iter();
     let args_null =
         func_call_info.argnull[..num_args]
-        .into_iter()
+        .iter()
         .map(|b| pg_bool::Bool::from(*b));
 
     (args, args_null)

--- a/pg-extend/src/pg_datum.rs
+++ b/pg-extend/src/pg_datum.rs
@@ -118,8 +118,10 @@ impl TryFromPgDatum for String {
         if let Some(datum) = datum.0 {
             let text_val = datum as *const pg_sys::text;
 
-            let val: *mut c_char = unsafe { pg_sys::text_to_cstring(text_val) };
-            let cstr = unsafe { CStr::from_ptr(val) };
+            let cstr = unsafe {
+                let val: *mut c_char = pg_sys::text_to_cstring(text_val);
+                CStr::from_ptr(val)
+            };
 
             match cstr.to_str() {
                 Ok(s) => Ok(s.to_owned()),

--- a/pg-extend/src/pg_fdw.rs
+++ b/pg-extend/src/pg_fdw.rs
@@ -187,7 +187,7 @@ impl<T: ForeignData> ForeignWrapper<T> {
             let mut data = vec![0 as pg_sys::Datum; attrs.len()];
             // Boolean array
             let mut isnull = vec![pgbool!(true); attrs.len()];
-            for (i, pattr) in attrs.into_iter().enumerate() {
+            for (i, pattr) in attrs.iter().enumerate() {
                 // TODO: There must be a better way to do this?
                 let result = Self::get_field(&(**pattr), &(*row));
                 match result {
@@ -259,8 +259,10 @@ impl<T: ForeignData> ForeignWrapper<T> {
             #[cfg(feature = "postgres-11")]
             ReparameterizeForeignPathByChild: None,
 
-            #[cfg(not(feature = "postgres-9"))]
+            #[cfg(any(feature = "postgres-10", feature = "postgres-11"))]
             ShutdownForeignScan: None,
+            #[cfg(any(feature = "postgres-10", feature = "postgres-11"))]
+            ReInitializeDSMForeignScan: None,
 
             GetForeignJoinPaths: None,
             GetForeignUpperPaths: None,
@@ -291,9 +293,6 @@ impl<T: ForeignData> ForeignWrapper<T> {
 
             EstimateDSMForeignScan: None,
             InitializeDSMForeignScan: None,
-
-            #[cfg(not(feature = "postgres-9"))]
-            ReInitializeDSMForeignScan: None,
 
             InitializeWorkerForeignScan: None,
         });

--- a/pg-extend/src/pg_fdw.rs
+++ b/pg-extend/src/pg_fdw.rs
@@ -175,11 +175,11 @@ impl<T: ForeignData> ForeignWrapper<T> {
             };
 
             #[cfg(not(feature = "postgres-11"))]
-            let (tupledesc, attrs) = {
-                let mut tupledesc = *(*(*node).ss.ss_currentRelation).rd_att;
+            let (mut tupledesc, attrs) = {
+                let tupledesc = *(*(*node).ss.ss_currentRelation).rd_att;
                 let attrs: &[pg_sys::Form_pg_attribute] =
                     std::slice::from_raw_parts(tupledesc.attrs, tupledesc.natts as usize);
-                
+
                 (tupledesc, attrs)
             };
 

--- a/pg-extend/src/pg_type.rs
+++ b/pg-extend/src/pg_type.rs
@@ -203,6 +203,12 @@ impl PgTypeInfo for String {
     }
 }
 
+impl PgTypeInfo for std::ffi::CString {
+    fn pg_type() -> PgType {
+        PgType::Text
+    }
+}
+
 impl PgTypeInfo for () {
     fn pg_type() -> PgType {
         PgType::Null

--- a/pg-extend/src/pg_type.rs
+++ b/pg-extend/src/pg_type.rs
@@ -197,6 +197,12 @@ impl PgTypeInfo for i64 {
     }
 }
 
+impl PgTypeInfo for String {
+    fn pg_type() -> PgType {
+        PgType::Text
+    }
+}
+
 impl PgTypeInfo for () {
     fn pg_type() -> PgType {
         PgType::Null

--- a/pg-extend/wrapper.h
+++ b/pg-extend/wrapper.h
@@ -13,4 +13,5 @@
 #include "optimizer/pathnode.h"
 #include "optimizer/planmain.h"
 #include "optimizer/restrictinfo.h"
+#include "utils/builtins.h"
 #include "utils/rel.h"


### PR DESCRIPTION
Added impls for `From<String> for PgDatum` and `TryFromPgDatum for String`. I haven't done much FFI before so while I don't think this introduces any memory leaks and some simple testing seems to confirm that, it's definitely possible I've missed something.

Updates to `examples/` and `integration-tests/` are coming.

I also switched up `build.rs` a bit so rather than checking for postgres.rs it signals to rustc that it should only rebuild if wrapper.h has changed. This might not be the behaviour you want, so can undo this if you'd prefer.

Lastly, I fixed up the `pg_fdw` module so it'd compile against Pg 11 and added a feature flag.