### PR TITLE
FDW can now read and write!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "backtrace"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "base64"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,22 +77,23 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.41.0"
+version = "0.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cexpr 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cexpr 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "clang-sys 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clang-sys 0.26.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "which 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -108,10 +136,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cexpr"
-version = "0.2.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 4.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -121,17 +149,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clang"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "clang-sys 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clang-sys 0.26.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "clang-sys"
-version = "0.23.0"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -177,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.5.13"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -185,6 +212,14 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -239,6 +274,15 @@ dependencies = [
 name = "glob"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "hashbrown"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "hex"
@@ -335,10 +379,11 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "3.2.1"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -358,8 +403,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "pg-extend"
 version = "0.2.1"
 dependencies = [
- "bindgen 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clang 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bindgen 0.47.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clang 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -432,14 +477,6 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "proc-macro2"
 version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -450,14 +487,6 @@ dependencies = [
 name = "quick-error"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "quote"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "quote"
@@ -521,8 +550,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "safemem"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "scopeguard"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -660,9 +699,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "which"
-version = "1.0.5"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -712,29 +752,34 @@ dependencies = [
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
+"checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
+"checksum backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b5b493b66e03090ebc4343eb02f94ff944e0cbc9ac6571491d170ba026741eb5"
+"checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
-"checksum bindgen 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e64eeb92e16bd21d6c95738458f80b2c95bad56cc8eeef7fdfaaf70268c56fe3"
+"checksum bindgen 0.47.1 (registry+https://github.com/rust-lang/crates.io-index)" = "91f5aa1a54c5997396b59cfac31af9c1cbcaa988958c4ce84364257b2cadfad0"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
 "checksum bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "40ade3d27603c2cb345eb0912aec461a6dec7e06a4ae48589904e808335c7afa"
 "checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
-"checksum cexpr 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "42aac45e9567d97474a834efdee3081b3c942b2205be932092f53354ce503d6c"
+"checksum cexpr 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "644d693ecfa91955ed32dcc7eda4914e1be97a641fb6f0645a37348e20b230da"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
-"checksum clang 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "26c4a9fd36cd08afe44217c95f31698862e48bee3380cbc60184d95c91abf996"
-"checksum clang-sys 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d7f7c04e52c35222fffcc3a115b5daf5f7e2bfb71c13c4e2321afe1fc71859c2"
+"checksum clang 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8266bf0bdde7b6e30a3e5a5d98906c4f5b08e8c94bcdd46c9f1091b0cc635bd"
+"checksum clang-sys 0.26.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6ef0c1bcf2e99c649104bd7a7012d8f8802684400e03db0ec0af48583c6fa0e4"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum crypto-mac 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0999b4ff4d3446d4ddb19a63e9e00c1876e75cd7000d20e57a693b4b3f08d958"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
-"checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
+"checksum env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "afb070faf94c85d17d50ca44f6ad076bce18ae92f0037d350947240a36e9d42e"
+"checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eb7217124812dc5672b7476d0c2d20cfe9f7c0f1ba0904b674a9762a0212f72e"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+"checksum hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
 "checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
 "checksum hmac 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44f3bdb08579d99d7dc761c0e266f13b5f2ab8c8c703b9fc9ef333cd8f48f55e"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
@@ -747,17 +792,15 @@ dependencies = [
 "checksum md5 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "79c56d6a0b07f9e19282511c83fc5b086364cbae4ba8c7d5f190c3d9b0425a48"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "db4c41318937f6e76648f42826b1d9ade5c09cafb5aef7e351240a70f39206e9"
-"checksum nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
+"checksum nom 4.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b30adc557058ce00c9d0d7cb3c6e0b5bc6f36e2e2eabe74b0ba726d194abd588"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum phf 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)" = "cec29da322b242f4c3098852c77a0ca261c9c01b806cae85a5572a1eb94db9a6"
 "checksum phf_shared 0.7.23 (registry+https://github.com/rust-lang/crates.io-index)" = "b539898d22d4273ded07f64a05737649dc69095d92cb87c7097ec68e3f150b93"
 "checksum postgres 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "115dde90ef51af573580c035857badbece2aa5cde3de1dfb3c932969ca92a6c5"
 "checksum postgres-protocol 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2487e66455bf88a1b247bf08a3ce7fe5197ac6d67228d920b0ee6a0e97fd7312"
 "checksum postgres-shared 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ffac35b3e0029b404c24a3b82149b4e904f293e8ca4a327eefa24d3ca50df36f"
-"checksum proc-macro2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "77997c53ae6edd6d187fec07ec41b207063b5ee6f33680e9fa86d405cdd313d4"
 "checksum proc-macro2 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)" = "77619697826f31a02ae974457af0b29b723e5619e113e9397b8b82c6bd253f09"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
-"checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
 "checksum quote 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "53fa22a1994bd0f9372d7a816207d8a2677ad0325b073f5c5332760f0fb62b5c"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
 "checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
@@ -765,7 +808,9 @@ dependencies = [
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f"
 "checksum regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4e47a2ed29da7a9e1960e1639e7a982e6edc6d49be308a3b02daf511504a16d1"
+"checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
+"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 "checksum socket2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c4d11a52082057d87cb5caa31ad812f4504b97ab44732cd8359df2e9ff9f48e7"
@@ -785,7 +830,7 @@ dependencies = [
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
-"checksum which 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e84a603e7e0b1ce1aa1ee2b109c7be00155ce52df5081590d1ffb93f4f515cb2"
+"checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "fdw-rw"
+version = "0.1.0"
+dependencies = [
+ "pg-extend 0.2.1",
+ "pg-extern-attr 0.2.2",
+]
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,6 @@ members = [
     "examples/adding", 
     "examples/panicking",
     "examples/fdw",
+    "examples/fdw-rw",
     "integration-tests",
 ]

--- a/examples/fdw-rw/Cargo.toml
+++ b/examples/fdw-rw/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "fdw-rw"
+version = "0.1.0"
+authors = ["Ellie Frost <web@stillinbeta.com>"]
+edition = "2018"
+
+[features]
+pg_allocator = []
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+pg-extern-attr = { version = "*", path = "../../pg-extern-attr" }
+pg-extend = { version = "*", path = "../../pg-extend" }

--- a/examples/fdw-rw/src/lib.rs
+++ b/examples/fdw-rw/src/lib.rs
@@ -9,7 +9,7 @@ extern crate pg_extend;
 extern crate pg_extern_attr;
 
 use pg_extend::pg_fdw::{ForeignData, ForeignRow, OptionMap, Tuple};
-use pg_extend::{pg_datum, pg_magic, pg_type};
+use pg_extend::{pg_datum, pg_magic, pg_type, pg_error};
 use pg_extern_attr::pg_foreignwrapper;
 use pg_extend::pg_datum::TryFromPgDatum;
 
@@ -81,7 +81,7 @@ impl ForeignData for CacheFDW {
         CacheFDW { inner: vecs }
     }
 
-    fn update(&self, new_row: Tuple, indices: Tuple) -> Option<Box<ForeignRow>> {
+    fn update(&self, new_row: &Tuple, indices: &Tuple) -> Option<Box<ForeignRow>> {
         let mut c = get_cache().write().unwrap();
         let key = indices.get("key");
         let value = new_row.get("value");
@@ -93,8 +93,21 @@ impl ForeignData for CacheFDW {
                 c.insert(key.clone(), value.clone());
                 Some(Box::new(MyRow{key, value}))
             }
-            _ => None
+            _ => {
+                pg_error::log(
+                    pg_error::Level::Info,
+                    file!(),
+                    line!(),
+                    module_path!(),
+                    format!("Missing key ({:?}) or value ({:?})", key, value),
+                );
+                None
+            }
         }
     }
 
+    fn insert(&self, new_row: &Tuple) -> Option<Box<ForeignRow>> {
+        // Since we only use one field from each, these methods are equivalent
+        self.update(new_row, new_row)
+    }
 }

--- a/examples/fdw-rw/src/lib.rs
+++ b/examples/fdw-rw/src/lib.rs
@@ -8,7 +8,7 @@
 extern crate pg_extend;
 extern crate pg_extern_attr;
 
-use pg_extend::pg_fdw::{ForeignRow, ForeignData, OptionMap};
+use pg_extend::pg_fdw::{ForeignData, ForeignRow, OptionMap};
 use pg_extend::{pg_datum, pg_magic, pg_type};
 use pg_extern_attr::pg_foreignwrapper;
 
@@ -18,12 +18,12 @@ use std::sync::RwLock;
 // Needs feature(staticmutex)
 // use std::sync::{StaticMutex, MUTEX_INIT};
 // static LOCK: StaticMutex = MUTEX_INIT;
-static mut _CACHE: Option<RwLock<HashMap<String,String>>> = None;
+static mut _CACHE: Option<RwLock<HashMap<String, String>>> = None;
 
-fn get_cache() -> &'static RwLock<HashMap<String,String>> {
+fn get_cache() -> &'static RwLock<HashMap<String, String>> {
     // let _g = LOCK.lock().unwrap();
     unsafe {
-        if let None = _CACHE {
+        if _CACHE.is_none() {
             let rw = RwLock::new(HashMap::new());
             _CACHE = Some(rw)
         }
@@ -35,8 +35,8 @@ fn get_cache() -> &'static RwLock<HashMap<String,String>> {
 pg_magic!(version: pg_sys::PG_VERSION_NUM);
 
 #[pg_foreignwrapper]
-struct CacheFDW{
-    inner: Vec<(String,String)>,
+struct CacheFDW {
+    inner: Vec<(String, String)>,
 }
 
 struct MyRow {
@@ -64,7 +64,10 @@ impl Iterator for CacheFDW {
     fn next(&mut self) -> Option<Self::Item> {
         match self.inner.pop() {
             None => None,
-            Some((k, v)) => Some(Box::new(MyRow{key: k.to_string(), value: v.to_string()})),
+            Some((k, v)) => Some(Box::new(MyRow {
+                key: k.to_string(),
+                value: v.to_string(),
+            })),
         }
     }
 }

--- a/examples/fdw-rw/src/lib.rs
+++ b/examples/fdw-rw/src/lib.rs
@@ -133,7 +133,7 @@ impl ForeignData for CacheFDW {
                     file!(),
                     line!(),
                     module_path!(),
-                    format!("Delete called without Key"),
+                    "Delete called without Key".to_string(),
                 );
                 None
             }

--- a/examples/fdw-rw/src/lib.rs
+++ b/examples/fdw-rw/src/lib.rs
@@ -1,0 +1,79 @@
+// Copyright 2018 Liz Frost <web@stillinbeta.com>
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+extern crate pg_extend;
+extern crate pg_extern_attr;
+
+use pg_extend::pg_fdw::{ForeignRow, ForeignData, OptionMap};
+use pg_extend::{pg_datum, pg_magic, pg_type};
+use pg_extern_attr::pg_foreignwrapper;
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+// Needs feature(staticmutex)
+// use std::sync::{StaticMutex, MUTEX_INIT};
+// static LOCK: StaticMutex = MUTEX_INIT;
+static mut _CACHE: Option<RwLock<HashMap<String,String>>> = None;
+
+fn get_cache() -> &'static RwLock<HashMap<String,String>> {
+    // let _g = LOCK.lock().unwrap();
+    unsafe {
+        if let None = _CACHE {
+            let rw = RwLock::new(HashMap::new());
+            _CACHE = Some(rw)
+        }
+        &_CACHE.as_ref().unwrap()
+    }
+}
+
+/// This tells Postges this library is a Postgres extension
+pg_magic!(version: pg_sys::PG_VERSION_NUM);
+
+#[pg_foreignwrapper]
+struct CacheFDW{
+    inner: Vec<(String,String)>,
+}
+
+struct MyRow {
+    key: String,
+    value: String,
+}
+
+impl ForeignRow for MyRow {
+    fn get_field(
+        &self,
+        name: &str,
+        _typ: pg_type::PgType,
+        _opts: OptionMap,
+    ) -> Result<Option<pg_datum::PgDatum>, &str> {
+        match name {
+            "key" => Ok(Some(self.key.clone().into())),
+            "value" => Ok(Some(self.value.clone().into())),
+            _ => Err("unknown field"),
+        }
+    }
+}
+
+impl Iterator for CacheFDW {
+    type Item = Box<ForeignRow>;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.inner.pop() {
+            None => None,
+            Some((k, v)) => Some(Box::new(MyRow{key: k.to_string(), value: v.to_string()})),
+        }
+    }
+}
+
+impl ForeignData for CacheFDW {
+    fn begin(_sopts: OptionMap, _topts: OptionMap) -> Self {
+        let c = get_cache().read().unwrap();
+        let vecs = c.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+
+        CacheFDW { inner: vecs }
+    }
+}

--- a/pg-extend/src/lib.rs
+++ b/pg-extend/src/lib.rs
@@ -19,7 +19,7 @@ pub mod pg_type;
 pub mod pg_fdw;
 
 /// A macro for marking a library compatible with the Postgres extension framework.
-/// 
+///
 /// This macro was initially inspired from the `pg_module` macro in https://github.com/thehydroimpulse/postgres-extension.rs
 #[macro_export]
 macro_rules! pg_magic {

--- a/pg-extend/src/pg_datum.rs
+++ b/pg-extend/src/pg_datum.rs
@@ -16,6 +16,7 @@ use std::ffi::{CStr, CString};
 ///
 /// This simplifies the semantics around Nullability of the Datum value, and provides conversion tools
 ///   between Datum and Rust types
+#[derive(Clone, Debug)]
 pub struct PgDatum(Option<Datum>);
 
 impl PgDatum {

--- a/pg-extend/src/pg_fdw.rs
+++ b/pg-extend/src/pg_fdw.rs
@@ -319,10 +319,13 @@ impl<T: ForeignData> ForeignWrapper<T> {
 
         let fields = Self::tts_to_hashmap(slot);
         let fields_with_index = Self::tts_to_hashmap(plan_slot);
-        (*wrapper).state.update(fields, fields_with_index);
+        let result = (*wrapper).state.update(fields, fields_with_index);
 
-        // TODO return an actual row
-        std::ptr::null_mut()
+        if result.is_none() {
+            std::ptr::null_mut()
+        } else {
+            slot
+        }
     }
 
     /// Turn this into an actual foreign data wrapper object.

--- a/pg-extend/src/pg_fdw.rs
+++ b/pg-extend/src/pg_fdw.rs
@@ -217,7 +217,7 @@ impl<T: ForeignData> ForeignWrapper<T> {
         row.get_field(&name, typ, opts).map_err(|e| e.into())
     }
 
-    fn tts_to_hashmap(slot: *mut pg_sys::TupleTableSlot, tupledesc: pg_sys::TupleDesc) -> Tuple {
+    fn tts_to_hashmap(slot: *mut pg_sys::TupleTableSlot, tupledesc: &pg_sys::tupleDesc) -> Tuple {
         let attrs = unsafe { Self::tupdesc_attrs(tupledesc) };
 
         // Make sure the slot is fully populated
@@ -242,9 +242,7 @@ impl<T: ForeignData> ForeignWrapper<T> {
         t
     }
 
-    // This isn't quite 'static, but it will last for the duration of the
-    // callback, which is good enough
-    unsafe fn tupdesc_attrs(tupledesc: pg_sys::TupleDesc) -> &'static [pg_sys::Form_pg_attribute] {
+    unsafe fn tupdesc_attrs(tupledesc: &pg_sys::tupleDesc) -> &[pg_sys::Form_pg_attribute] {
         #[cfg(feature = "postgres-11")]
         let attrs = (*tupledesc).attrs.as_ptr() as *const _;
         #[cfg(not(feature = "postgres-11"))]
@@ -269,7 +267,7 @@ impl<T: ForeignData> ForeignWrapper<T> {
 
         let ret = if let Some(row) = (*wrapper).state.next() {
             let tupledesc = (*(*node).ss.ss_currentRelation).rd_att;
-            let attrs = Self::tupdesc_attrs(tupledesc);
+            let attrs = Self::tupdesc_attrs(&*tupledesc);
 
             // Datum array
             let mut data = vec![0 as pg_sys::Datum; attrs.len()];
@@ -339,7 +337,7 @@ impl<T: ForeignData> ForeignWrapper<T> {
 
             // Build a map of column names to attributes
             let attrs: HashMap<String, &pg_sys::Form_pg_attribute> =
-                Self::tupdesc_attrs((*target_relation).rd_att)
+                Self::tupdesc_attrs(&*(*target_relation).rd_att)
                 .iter()
                 .map(|rel| (Self::name_to_string((**rel).attname), rel))
                 .collect();
@@ -419,8 +417,8 @@ impl<T: ForeignData> ForeignWrapper<T> {
     ) -> *mut pg_sys::TupleTableSlot {
         let wrapper = Box::from_raw((*rinfo).ri_FdwState as *mut Self);
 
-        let fields = Self::tts_to_hashmap(slot, (*slot).tts_tupleDescriptor);
-        let fields_with_index = Self::tts_to_hashmap(plan_slot, (*plan_slot).tts_tupleDescriptor);
+        let fields = Self::tts_to_hashmap(slot, &*(*slot).tts_tupleDescriptor);
+        let fields_with_index = Self::tts_to_hashmap(plan_slot, &*(*plan_slot).tts_tupleDescriptor);
         let result = (*wrapper).state.update(&fields, &fields_with_index);
 
         if result.is_none() {
@@ -439,7 +437,7 @@ impl<T: ForeignData> ForeignWrapper<T> {
     ) -> *mut pg_sys::TupleTableSlot {
         let wrapper = Box::from_raw((*rinfo).ri_FdwState as *mut Self);
 
-        let fields_with_index = Self::tts_to_hashmap(plan_slot, (*plan_slot).tts_tupleDescriptor);
+        let fields_with_index = Self::tts_to_hashmap(plan_slot, &*(*plan_slot).tts_tupleDescriptor);
 
         let result = (*wrapper).state.delete(&fields_with_index);
 
@@ -463,7 +461,7 @@ impl<T: ForeignData> ForeignWrapper<T> {
         let wrapper = Box::from_raw((*rinfo).ri_FdwState as *mut Self);
 
         let tupledesc = (*(*rinfo).ri_RelationDesc).rd_att;
-        let fields = Self::tts_to_hashmap(slot, tupledesc);
+        let fields = Self::tts_to_hashmap(slot, &*tupledesc);
 
         let result = (*wrapper).state.insert(&fields);
 

--- a/pg-extend/wrapper.h
+++ b/pg-extend/wrapper.h
@@ -6,10 +6,14 @@
 // copied, modified, or distributed except according to those terms.
 
 #include "postgres.h"
+#include "postgres_ext.h"
 #include "access/relscan.h"
+#include "access/sysattr.h"
 #include "catalog/pg_type.h"
 #include "executor/spi.h"
 #include "foreign/fdwapi.h"
+#include "nodes/makefuncs.h"
+#include "nodes/pg_list.h"
 #include "optimizer/pathnode.h"
 #include "optimizer/planmain.h"
 #include "optimizer/restrictinfo.h"


### PR DESCRIPTION
Here's my little test script:

```sql
DROP FUNCTION cachefdw() CASCADE;

CREATE FUNCTION cachefdw() RETURNS fdw_handler
    AS '/home/ellie/Projects/pg-extend-rs/target/debug/libfdw_rw.so', 'fdw_CacheFDW'
    LANGUAGE C STRICT;


CREATE FOREIGN DATA WRAPPER dfdw handler cachefdw NO VALIDATOR;

CREATE SERVER df FOREIGN DATA WRAPPER dfdw;

CREATE FOREIGN TABLE mytable ( key text, value text ) SERVER df ;

INSERT INTO mytable (key, value) VALUES
  ('celestia', 'alicorn')
;

INSERT INTO mytable (key, value) VALUES
  ('twilight sparkle', 'unicorn')
, ('applejack', 'earth pony')
, ('fluttershy', 'pegasus')
, ('pinkie pie', 'earth pony')
, ('rainbow dash', 'pegasus')
, ('rarity', 'unicorn')
, ('discord', 'draconequus')
;

UPDATE mytable SET value='alicorn' where key='twilight sparkle';

DELETE FROM mytable WHERE key = 'discord';

SELECT * FROM mytable;
```

I promise I'll write that integration test soon! I'm at @recursecenter so I've got a lot of time to devote to fun diversions like this :)