### PR TITLE
Fixes for PostgreSQL 9 & a small build enhancement

### DIFF
--- a/pg-extend/build.rs
+++ b/pg-extend/build.rs
@@ -94,10 +94,13 @@ fn get_postgres_feature_version(pg_include: String) -> &'static str {
         e.get_kind() == clang::EntityKind::StringLiteral
     }).expect("couldn't find string literal for major version");
 
-    match string_literal.get_display_name().unwrap().as_str() {
-        "\"9\"" => "postgres-9",
-        "\"10\"" => "postgres-10",
-        "\"11\"" => "postgres-11",
+    let version = string_literal.get_display_name().unwrap().replace("\"", "");
+    let version = version.split(".").collect::<Vec<_>>();
+
+    match &version[..] {
+        ["9", _] => "postgres-9",
+        ["10"] => "postgres-10",
+        ["11"] => "postgres-11",
         val => panic!("unknown postgres version {:?}", val),
     }
 }

--- a/pg-extend/src/lib.rs
+++ b/pg-extend/src/lib.rs
@@ -16,6 +16,7 @@ pub mod pg_datum;
 pub mod pg_error;
 pub mod pg_sys;
 pub mod pg_type;
+#[cfg(not(feature = "postgres-9"))]
 pub mod pg_fdw;
 
 /// A macro for marking a library compatible with the Postgres extension framework.

--- a/pg-extend/src/pg_error.rs
+++ b/pg-extend/src/pg_error.rs
@@ -35,6 +35,7 @@ pub enum Level {
     Log = pg_sys::LOG as isize,
     /// Same as LOG for server reporting, but never sent to client.
     ///   `CommError` is an alias for this
+    #[cfg(not(feature = "postgres-9"))]
     LogServerOnly = pg_sys::LOG_SERVER_ONLY as isize,
     /// Messages specifically requested by user (eg VACUUM VERBOSE output); always sent to client regardless of client_min_messages, but by default not sent to server log.
     Info = pg_sys::INFO as isize,

--- a/pg-extend/src/pg_sys.rs
+++ b/pg-extend/src/pg_sys.rs
@@ -13,7 +13,7 @@
 #![allow(clippy::approx_constant)]
 #![allow(clippy::cast_lossless)]
 #![allow(clippy::const_static_lifetime)]
-#![allow(clippy::new_without_default_derive)]
+#![allow(clippy::new_without_default)]
 #![allow(clippy::should_implement_trait)]
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::trivially_copy_pass_by_ref)]


### PR DESCRIPTION
Hello, thank you for writing pg-extend, it's incredibly useful! We have a number of postgres extensions, including some written in Rust and not having to deal with C glue code, PGXS, and Makefiles is great.

Unfortunately we're still on postgres 9, so here are a few small fixes to version detection and features. I've tested it against 9.4.

I also updated the build script to run `pg_config --includedir-server` if `PG_INCLUDE_PATH` isn't set so in the simple case that won't be required, but is available as an override.