### PR TITLE
Automatic conversion between SQL NULL and Option<T> types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,6 +872,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "nullable"
+version = "0.1.0"
+dependencies = [
+ "pg-extend 0.2.1",
+ "pg-extern-attr 0.2.2",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "pg-extend", 
     "pg-extern-attr", 
     "examples/adding", 
+    "examples/nullable",
     "examples/panicking",
     "examples/fdw",
     "examples/fdw-rw",

--- a/examples/nullable/Cargo.toml
+++ b/examples/nullable/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "nullable"
+version = "0.1.0"
+authors = ["Marti Raudsepp <marti@juffo.org"]
+edition = "2018"
+
+[features]
+pg_allocator = []
+
+[lib]
+crate-type = ["cdylib"]
+
+[[bin]]
+name = "nullable-stmt"
+path = "src/bin.rs"
+
+[dependencies]
+pg-extern-attr = { version = "*", path = "../../pg-extern-attr" }
+pg-extend = { version = "*", path = "../../pg-extend" }

--- a/examples/nullable/README.md
+++ b/examples/nullable/README.md
@@ -1,0 +1,18 @@
+# Rust based postgres extension
+
+An example of the NULLIF() conditional expression implemented in Rust, taking
+advntage of optional (NULL or Option<>) arguments and return type.
+
+To build, get Rust, then (the RUSTFLAGS is required to build the library):
+
+```console
+$> RUSTFLAGS="-C link-arg=-undefineddynamic_lookup" cargo build --release
+...
+```
+
+then load into postgres
+
+```console
+$> psql $CONN_STR
+postgres=# CREATE FUNCTION rs_nullif(text,text) RETURNS text AS 'path/to/libnullable.dylib', 'pg_rs_nullif' LANGUAGE C;
+```

--- a/examples/nullable/src/bin.rs
+++ b/examples/nullable/src/bin.rs
@@ -1,0 +1,8 @@
+extern crate pg_extend;
+
+use pg_extend::pg_create_stmt_bin;
+
+pg_create_stmt_bin!(
+    get_null_pg_create_stmt,
+    rs_nullif_pg_create_stmt
+);

--- a/examples/nullable/src/lib.rs
+++ b/examples/nullable/src/lib.rs
@@ -1,0 +1,50 @@
+// Copyright 2019 Marti Raudsepp <marti@juffo.org>
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+extern crate pg_extern_attr;
+extern crate pg_extend;
+
+use pg_extern_attr::pg_extern;
+use pg_extend::pg_magic;
+
+/// This tells Postgres this library is a Postgres extension
+pg_magic!(version: pg_sys::PG_VERSION_NUM);
+
+
+/// Simply returns NULL. For testing a function with no arguments.
+#[pg_extern]
+fn get_null() -> Option<i32> {
+    None
+}
+
+
+/// The NULLIF function returns a null value if value1 equals value2; otherwise it returns value1
+/// https://www.postgresql.org/docs/current/functions-conditional.html#FUNCTIONS-NULLIF
+#[pg_extern]
+fn rs_nullif(value1: Option<String>, value2: Option<String>) -> Option<String> {
+    if value1 == value2 { None } else { value1 }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_null() {
+        assert_eq!(get_null(), None);
+    }
+
+    #[test]
+    fn test_rs_nullif() {
+        assert_eq!(rs_nullif(Some("a".to_string()), Some("-".to_string())), Some("a".to_string()));
+        assert_eq!(rs_nullif(Some("a".to_string()), None), Some("a".to_string()));
+        assert_eq!(rs_nullif(Some("-".to_string()), Some("-".to_string())), None);
+        assert_eq!(rs_nullif(None, Some("-".to_string())), None);
+        assert_eq!(rs_nullif(None, None), None);
+    }
+}

--- a/integration-tests/tests/adding_tests.rs
+++ b/integration-tests/tests/adding_tests.rs
@@ -12,6 +12,31 @@ fn test_add_one() {
         let col: i32 = row.get(0);
 
         assert_eq!(col, 2);
+
+        // Calling the function with NULL argument returns NULL because it's declared STRICT
+        let result = conn.query("SELECT add_one(NULL)", &[]).expect("query failed");
+        assert_eq!(result.len(), 1);
+
+        let row = result.get(0);
+        let col: Option<i32> = row.get(0);
+
+        assert_eq!(col, None);
+    });
+}
+
+#[test]
+fn test_add_one_null() {
+    test_in_db("adding", |conn| {
+        // Rust add_big_one function should not be called because we declare it STRICT.
+        let result = conn
+            .query("SELECT add_big_one(CAST(NULL as int8))",&[])
+            .expect("query failed");
+        assert_eq!(result.len(), 1);
+
+        let row = result.get(0);
+        let col: Option<i64> = row.get(0);
+
+        assert_eq!(col, None);
     });
 }
 

--- a/integration-tests/tests/nullable_tests.rs
+++ b/integration-tests/tests/nullable_tests.rs
@@ -1,0 +1,57 @@
+extern crate integration_tests;
+
+use integration_tests::*;
+
+#[test]
+fn test_get_null() {
+    test_in_db("nullable", |conn| {
+        let result = conn.query("SELECT get_null()", &[]).expect("query failed");
+        assert_eq!(result.len(), 1);
+
+        let row = result.get(0);
+        let col: Option<i32> = row.get(0);
+
+        assert_eq!(col, None);
+    });
+}
+
+#[test]
+fn test_rs_nullif() {
+    test_in_db("nullable", |conn| {
+        // 'a', 'b' => 'a'
+        let result = conn.query("SELECT rs_nullif('a', 'b')", &[]).expect("query failed");
+        assert_eq!(result.len(), 1);
+
+        let row = result.get(0);
+        let col: Option<String> = row.get(0);
+
+        assert_eq!(col, Some("a".to_string()));
+
+        // '-', '-' => NULL
+        let result = conn.query("SELECT rs_nullif('-', '-')", &[]).expect("query failed");
+        assert_eq!(result.len(), 1);
+
+        let row = result.get(0);
+        let col: Option<String> = row.get(0);
+
+        assert_eq!(col, None);
+
+        // 'a', NULL => 'a'
+        let result = conn.query("SELECT rs_nullif('a', NULL)", &[]).expect("query failed");
+        assert_eq!(result.len(), 1);
+
+        let row = result.get(0);
+        let col: Option<String> = row.get(0);
+
+        assert_eq!(col, Some("a".to_string()));
+
+        // NULL, '-' => NULL
+        let result = conn.query("SELECT rs_nullif(NULL, '-')", &[]).expect("query failed");
+        assert_eq!(result.len(), 1);
+
+        let row = result.get(0);
+        let col: Option<String> = row.get(0);
+
+        assert_eq!(col, None);
+    });
+}

--- a/pg-extend/src/pg_type.rs
+++ b/pg-extend/src/pg_type.rs
@@ -177,6 +177,8 @@ impl PgType {
 pub trait PgTypeInfo {
     /// return the Postgres type
     fn pg_type() -> PgType;
+    /// for distinguishing optional and non-optional arguments
+    fn is_option() -> bool { false }
 }
 
 impl PgTypeInfo for i16 {
@@ -213,4 +215,12 @@ impl PgTypeInfo for () {
     fn pg_type() -> PgType {
         PgType::Null
     }
+}
+
+impl<T> PgTypeInfo for Option<T> where T: PgTypeInfo {
+    fn pg_type() -> PgType {
+        T::pg_type()
+    }
+
+    fn is_option() -> bool { true }
 }


### PR DESCRIPTION
I'm writing a pg-geoip extension based on pg-extend-rs (currently it's quite horrible, it's almost the first thing I've written in Rust).

I wanted to return a NULL result for calls where the IP is unknown to the GeoIP database, but I couldn't figure out how to return NULL currently with pg-extend-rs.

Since PostgreSQL supports NULL for every type of value, I figured it would be really nice if pg-extend-rs transparently supported `Option<>` types as return values. So I coded up this proof of concept and it appears to work!

Now, duplicating this for every supported type like this pull request is clearly ugly. I'm guessing it's also possible to do this in a generic way in Rust and I can look into it if I find the time. But before I spend more time trying that out, I wanted to see if you have any thoughts on the matter?
