### PR TITLE
Simpler macro interface for logging to PostgreSQL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,6 +798,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "logging"
+version = "0.1.0"
+dependencies = [
+ "pg-extend 0.2.1",
+ "pg-extern-attr 0.2.2",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,6 @@ members = [
     "examples/fdw",
     "examples/fdw-rw",
     "examples/strings",
+    "examples/logging",
     "integration-tests",
 ]

--- a/examples/fdw-rw/src/lib.rs
+++ b/examples/fdw-rw/src/lib.rs
@@ -10,7 +10,7 @@ extern crate pg_extern_attr;
 
 use pg_extend::pg_datum::TryFromPgDatum;
 use pg_extend::pg_fdw::{ForeignData, ForeignRow, OptionMap, Tuple};
-use pg_extend::{pg_datum, pg_error, pg_magic, pg_type};
+use pg_extend::{pg_datum, pg_magic, pg_type, info};
 use pg_extern_attr::pg_foreignwrapper;
 
 use std::collections::HashMap;
@@ -115,13 +115,7 @@ CREATE FOREIGN TABLE {schema}.mytable (
                 Some(Box::new(MyRow { key, value }))
             }
             _ => {
-                pg_error::log(
-                    pg_error::Level::Info,
-                    file!(),
-                    line!(),
-                    module_path!(),
-                    format!("Missing key ({:?}) or value ({:?})", key, value),
-                );
+                info!("Missing key ({:?}) or value ({:?})", key, value);
                 None
             }
         }
@@ -145,13 +139,7 @@ CREATE FOREIGN TABLE {schema}.mytable (
                 }
             }
             _ => {
-                pg_error::log(
-                    pg_error::Level::Info,
-                    file!(),
-                    line!(),
-                    module_path!(),
-                    "Delete called without Key".to_string(),
-                );
+                info!("Delete called without Key");
                 None
             }
         }

--- a/examples/logging/Cargo.toml
+++ b/examples/logging/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "logging"
+version = "0.1.0"
+authors = ["Marti Raudsepp <marti@juffo.org"]
+edition = "2018"
+
+[features]
+pg_allocator = []
+
+[lib]
+crate-type = ["cdylib"]
+
+[[bin]]
+name = "logging-stmt"
+path = "src/bin.rs"
+
+[dependencies]
+pg-extern-attr = { version = "*", path = "../../pg-extern-attr" }
+pg-extend = { version = "*", path = "../../pg-extend" }

--- a/examples/logging/README.md
+++ b/examples/logging/README.md
@@ -1,0 +1,15 @@
+# Example Postgres extension using logging
+
+To build, get Rust, then:
+
+```console
+$> cargo build --release
+...
+```
+
+then load into Postgres:
+
+```console
+$> psql $CONN_STR
+postgres=# CREATE FUNCTION rs_nullif(text,text) RETURNS text AS 'path/to/libnullable.dylib', 'pg_rs_nullif' LANGUAGE C;
+```

--- a/examples/logging/src/bin.rs
+++ b/examples/logging/src/bin.rs
@@ -1,0 +1,8 @@
+extern crate pg_extend;
+
+use pg_extend::pg_create_stmt_bin;
+
+pg_create_stmt_bin!(
+    rs_error_pg_create_stmt,
+    rs_log_all_pg_create_stmt
+);

--- a/examples/logging/src/lib.rs
+++ b/examples/logging/src/lib.rs
@@ -1,0 +1,38 @@
+// Copyright 2019 Marti Raudsepp <marti@juffo.org>
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+extern crate pg_extend;
+extern crate pg_extern_attr;
+
+use pg_extend::pg_magic;
+use pg_extend::{error, warn, notice, info, log, debug, trace};
+use pg_extern_attr::pg_extern;
+
+// This tells Postgres this library is a Postgres extension
+pg_magic!(version: pg_sys::PG_VERSION_NUM);
+
+/// An error in PostgreSQL aborts the current statement and (sub)transaction.
+#[pg_extern]
+fn rs_error(msg: String) {
+    error!("{}", msg);
+}
+
+/// Log messages in all non-error log levels.
+#[pg_extern]
+fn rs_log_all() {
+    warn!("TEST: This is a warning");
+    notice!("TEST: Notice this!");
+    info!("TEST: This is an info message");
+    log!("TEST: This is an LOG-level message");
+    debug!("TEST: This is a debug message");
+    trace!("TEST: This is a trace-level message")
+}
+
+#[cfg(test)]
+mod tests {
+    /* Cannot test this module wihtout a PostgreSQL runtime. */
+}

--- a/integration-tests/tests/logging.rs
+++ b/integration-tests/tests/logging.rs
@@ -1,0 +1,105 @@
+extern crate integration_tests;
+
+use core::mem;
+use std::sync::{Arc, Mutex};
+
+use postgres::{Connection, HandleNotice};
+use postgres::error::DbError;
+
+use integration_tests::*;
+
+#[test]
+fn test_rs_error() {
+    test_in_db("logging", |conn| {
+        let result = conn
+            .query("SELECT rs_error('No you dont!')", &[])
+            .expect_err("error not thrown");
+        assert_eq!(format!("{}", result), "database error: ERROR: No you dont!");
+    });
+}
+
+struct MsgCapture {
+    msgs: Arc<Mutex<Vec<DbError>>>,
+}
+
+/// Allows capturing log messages from a PostgreSQL connection.
+impl MsgCapture {
+    fn new() -> MsgCapture {
+        MsgCapture {
+            msgs: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+    /// Returns the current message buffer and flushes it.
+    fn drain(&self) -> Vec<DbError> {
+        let mut msgs = self.msgs.lock().unwrap();
+        mem::replace(&mut *msgs, Vec::new())
+    }
+    /// Returns a callback for Connection::set_notice_handler()
+    fn get_handler(&self) -> Box<HandleNotice> {
+        let msgs = self.msgs.clone();
+        // HandleNotice trait is implemented for FnMut(DbError)
+        return Box::new(move |e: DbError| {
+            msgs.lock().unwrap().push(e);
+        });
+    }
+}
+
+#[test]
+fn test_rs_log_all() {
+    test_in_db("logging", |conn: Connection| {
+        let capture = MsgCapture::new();
+
+        // Test with log level ERROR
+        // INFO messages are sent ot the client even at log level ERROR
+        // https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-CLIENT-MIN-MESSAGES
+        conn.query("SET client_min_messages=error", &[])
+            .expect("query failed");
+        let old_handler = conn.set_notice_handler(capture.get_handler());
+
+        conn.query("SELECT rs_log_all()", &[])
+            .expect("query failed");
+
+        let msgs = capture.drain();
+        assert_eq!(msgs[0].severity, "INFO");
+        assert_eq!(msgs[0].message, "TEST: This is an info message");
+        assert_eq!(msgs.len(), 1);
+
+        // Test with log level DEBUG5
+        conn.query("SET client_min_messages=debug5", &[])
+            .expect("query failed");
+        conn.query("SELECT rs_log_all()", &[])
+            .expect("query failed");
+
+        // Filter out PostgreSQL's own debug messages e.g.: "DEBUG: StartTransaction(1) ..."
+        // Our test messages all start with "TEST: "
+        let msgs: Vec<String> = capture
+            .drain()
+            .iter()
+            .filter_map(|m: &DbError| {
+                if m.severity != "DEBUG" || m.message.starts_with("TEST: ") {
+                    Some(format!("{}: {}", m.severity, m.message))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        assert_eq!(
+            msgs,
+            vec![
+                "WARNING: TEST: This is a warning",
+                "NOTICE: TEST: Notice this!",
+                "INFO: TEST: This is an info message",
+                "LOG: TEST: This is an LOG-level message",
+                // PostgreSQL clients don't distinguish between DEBUG1...DEBUG5 levels.
+                "DEBUG: TEST: This is a debug message",
+                "DEBUG: TEST: This is a trace-level message"
+            ]
+        );
+
+        // Clean up, restore old notice handler.
+        conn.query("RESET client_min_messages", &[])
+            .expect("query failed");
+        conn.set_notice_handler(old_handler);
+    });
+}

--- a/pg-extend/src/lib.rs
+++ b/pg-extend/src/lib.rs
@@ -19,6 +19,7 @@ pub mod pg_sys;
 pub mod pg_type;
 #[cfg(not(feature = "postgres-9"))]
 pub mod pg_fdw;
+pub mod log;
 
 /// A macro for marking a library compatible with the Postgres extension framework.
 ///
@@ -83,9 +84,7 @@ pub fn register_panic_handler() {
     // set (and replace the existing) panic handler, this will tell Postgres that the call failed
     //   a level of Fatal will force the DB connection to be killed.
     panic::set_hook(Box::new(|info| {
-        let level = pg_error::Level::Fatal;
-
-        pg_error::log(level, file!(), line!(), module_path!(), format!("panic in Rust extension: {}", info));
+        fatal!("panic in Rust extension: {}", info);
     }));
 }
 

--- a/pg-extend/src/log.rs
+++ b/pg-extend/src/log.rs
@@ -1,0 +1,238 @@
+// Copyright 2019 Marti Raudsepp <marti@juffo.org>
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Implements macros for the PostgreSQL logging system.
+//!
+//! For common log levels, convenient macros are implemented: [`trace!`], [`debug!`], [`log!`],
+//! [`info!`], [`notice!`], [`warn!`], [`error!`], [`fatal!`].
+//!
+//! Other log levels are supported with the generic macro [`pg_log!`]. See the [`Level` enum] for
+//! all available log levels.
+//!
+//! # Note
+//!
+//! Beware, log levels `ERROR` and higher also abort the current transaction. The PostgreSQL
+//! implementation uses exception handling with `longjmp`, which currently has unsafe side-effects.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use pg_extend::{info, pg_log};
+//! use pg_extend::log::Level;
+//!
+//! info!("{} widgets frobnicated", 10);
+//! pg_log!(Level::LogServerOnly, "Big brother is watching {}!", "you");
+//! ````
+//!
+//! # Rust `log` crate
+//!
+//! The macro names make this mostly a drop-in replacement for the Rust `log` crate. However, there
+//! are differences:
+//! * Due to PostgreSQL behavior, log levels `ERROR` and higher log levels abort the current
+//!   statement and transaction.
+//! * `pg_extend` macros do not support the optional `target:` argument.
+//! * In the `log` crate, the generic logging macro is called `log!`. However, we use that name as a
+//!   specialized macro since PostgreSQL has a `LOG` log level.
+//! * `Level` enum contains Postgres-specific log levels; there is no `Level::Trace` for instance.
+//!
+//! [`trace!`]: ../macro.trace.html
+//! [`debug!`]: ../macro.debug.html
+//! [`log!`]: ../macro.log.html
+//! [`info!`]: ../macro.info.html
+//! [`notice!`]: ../macro.notice.html
+//! [`warn!`]: ../macro.warn.html
+//! [`error!`]: ../macro.error.html
+//! [`fatal!`]: ../macro.fatal.html
+//! [`pg_log!`]: ../macro.pg_log.html
+//! [`Level` enum]: enum.Level.html
+
+use std::ffi::CString;
+use std::fmt;
+use std::os::raw::{c_char, c_int};
+
+use crate::pg_sys;
+
+/// Postgres logging Levels
+///
+/// # Note
+///
+/// Some of these levels effect the status of the connection and transaction in Postgres.
+/// Specifically, >= `Error` will cause the connection and transaction to fail and be reset.
+#[derive(Clone, Copy)]
+pub enum Level {
+    /// Debugging messages, in categories of 5 decreasing detail.
+    Debug5 = pg_sys::DEBUG5 as isize,
+    /// Debugging messages, in categories of 4 decreasing detail.
+    Debug4 = pg_sys::DEBUG4 as isize,
+    /// Debugging messages, in categories of 3 decreasing detail.
+    Debug3 = pg_sys::DEBUG3 as isize,
+    /// Debugging messages, in categories of 2 decreasing detail.
+    Debug2 = pg_sys::DEBUG2 as isize,
+    /// Debugging messages, in categories of 1 decreasing detail.
+    Debug1 = pg_sys::DEBUG1 as isize,
+    /// Server operational messages; sent only to server log by default.
+    Log = pg_sys::LOG as isize,
+    /// Same as LOG for server reporting, but never sent to client.
+    ///   `CommError` is an alias for this
+    #[cfg(not(feature = "postgres-9"))]
+    LogServerOnly = pg_sys::LOG_SERVER_ONLY as isize,
+    /// Messages specifically requested by user (eg VACUUM VERBOSE output); always sent to client
+    /// regardless of client_min_messages, but by default not sent to server log.
+    Info = pg_sys::INFO as isize,
+    /// Helpful messages to users about query operation; sent to client and not to server log by
+    /// default.
+    Notice = pg_sys::NOTICE as isize,
+    /// Warnings.  NOTICE is for expected messages like implicit sequence creation by SERIAL.
+    /// WARNING is for unexpected messages.
+    Warning = pg_sys::WARNING as isize,
+    /// user error - abort transaction; return to known state
+    Error = pg_sys::ERROR as isize,
+    /// fatal error - abort process
+    Fatal = pg_sys::FATAL as isize,
+    /// take down the other backends with me
+    Panic = pg_sys::PANIC as isize,
+}
+
+impl From<Level> for c_int {
+    fn from(level: Level) -> Self {
+        level as isize as c_int
+    }
+}
+
+/// Log a `DEBUG5` level message. This macro is included for easy replacement with Rust "log" crate
+/// macros.
+#[macro_export]
+macro_rules! trace {
+    ($($arg:tt)*) => (
+        $crate::pg_log!($crate::log::Level::Debug5, $($arg)*);
+    )
+}
+
+
+/// Log a `DEBUG1` level message. These are hidden by default
+#[macro_export]
+macro_rules! debug {
+    ($($arg:tt)*) => (
+        $crate::pg_log!($crate::log::Level::Debug1, $($arg)*);
+    )
+}
+
+/// Logs a `LOG` message. These messages have a high precedence for writing to PostgreSQL server
+/// logs but low precedence for sending to the client.
+#[macro_export]
+macro_rules! log {
+    ($($arg:tt)*) => (
+        $crate::pg_log!($crate::log::Level::Log, $($arg)*);
+    )
+}
+
+/// Log an `INFO` message. Used for information specifically requested by user (eg VACUUM VERBOSE
+/// output). These messages are always sent to the client regardless of
+/// `client_min_messages` setting, and not to server logs by default.
+#[macro_export]
+macro_rules! info {
+    ($($arg:tt)*) => (
+        $crate::pg_log!($crate::log::Level::Info, $($arg)*);
+    )
+}
+
+/// Log at `NOTICE` level. Use for helpful messages to users about query operation; expected
+/// messages like implicit sequence creation by SERIAL.
+#[macro_export]
+macro_rules! notice {
+    ($($arg:tt)*) => (
+        $crate::pg_log!($crate::log::Level::Notice, $($arg)*);
+    )
+}
+
+/// Log at `WARNING` level. Use for messages that are unexpected for the user.
+#[macro_export]
+macro_rules! warn {
+    ($($arg:tt)*) => (
+        $crate::pg_log!($crate::log::Level::Warning, $($arg)*);
+    )
+}
+
+/// Log at `ERROR` level and abort the current query and transaction.
+/// Beware! The PostgreSQL implementation uses exception handling with `longjmp`, which currently
+/// has unsafe side-effects.
+#[macro_export]
+macro_rules! error {
+    ($($arg:tt)*) => (
+        $crate::pg_log!($crate::log::Level::Error, $($arg)*);
+    )
+}
+
+/// Log a `FATAL` error and exit the current backend process, also closing the database connection.
+#[macro_export]
+macro_rules! fatal {
+    ($($arg:tt)*) => (
+        $crate::pg_log!($crate::log::Level::Fatal, $($arg)*);
+    )
+}
+
+/// Generic logging macro. See the [`Level` enum] for all available log levels.
+///
+/// Usually one wouldn't call this directly but the more convenient specialized macros.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use pg_extend::pg_log;
+/// use pg_extend::log::Level;
+///
+/// pg_log!(Level::LogServerOnly, "Big brother is watching {}!", "you");
+/// ````
+///
+/// [`Level` enum]: enum.Level.html
+#[macro_export]
+macro_rules! pg_log {
+    ($lvl:expr, $($arg:tt)+) => ({
+        $crate::log::__private_api_log(
+            format_args!($($arg)+),
+            $lvl,
+            // Construct a tuple; the whole tuple is a compile-time constant.
+            &(
+                // Construct zero-terminated strings at compile time.
+                concat!(module_path!(), "\0") as *const str as *const ::std::os::raw::c_char,
+                concat!(file!(), "\0") as *const str as *const ::std::os::raw::c_char,
+                line!(),
+            ),
+        );
+    });
+}
+
+// WARNING: this is not part of the crate's public API and is subject to change at any time
+#[doc(hidden)]
+pub fn __private_api_log(
+    args: fmt::Arguments,
+    level: Level,
+    &(module_path, file, line): &(*const c_char, *const c_char, u32),
+) {
+    let errlevel: c_int = c_int::from(level);
+    let line = line as c_int;
+    const LOG_DOMAIN: *const c_char = "RUST\0" as *const str as *const c_char;
+
+    // Rust has no "function name" macro, for now we use module path instead.
+    // See: https://github.com/rust-lang/rfcs/issues/1743
+    let do_log = unsafe { pg_sys::errstart(errlevel, file, line, module_path, LOG_DOMAIN) };
+
+    // If errstart returned false, the message won't be seen by anyone; logging will be skipped
+    if pgbool!(do_log) {
+        // At this point we format the passed format string `args`; if the log level is suppressed,
+        // no string processing needs to take place.
+        let msg = format!("{}", args);
+        let c_msg = CString::new(msg).or_else(
+            |_| CString::new("failed to convert msg to a CString, check extension code for incompatible `CString` messages")
+        ).expect("this should not fail: msg");
+
+        unsafe {
+            let msg_result = pg_sys::errmsg(c_msg.as_ptr());
+            pg_sys::errfinish(msg_result);
+        }
+    }
+}

--- a/pg-extend/src/pg_error.rs
+++ b/pg-extend/src/pg_error.rs
@@ -6,10 +6,14 @@
 // copied, modified, or distributed except according to those terms.
 
 //! Error reporting support for Postgres.
+//! This module is deprecated, use the logging macros in the [`pg_extend::log` module].
+//!
+//! [`pg_extend::log` module]: ../log/index.html
+#![allow(deprecated)]
 
-use std::os::raw::{c_int, c_char};
+use std::os::raw::{c_char, c_int};
 
-use crate::{pg_sys, pg_bool};
+use crate::{pg_bool, pg_sys};
 
 const ERR_DOMAIN: &[u8] = b"RUST\0";
 
@@ -20,6 +24,7 @@ const ERR_DOMAIN: &[u8] = b"RUST\0";
 /// Some of these levels effect the status of the connection and transaction in Postgres. Specifically, >= Error will cause
 ///   the connection and transaction to fail and be reset.
 #[derive(Clone, Copy)]
+#[deprecated = "use pg_extend::log::Level"]
 pub enum Level {
     /// Debugging messages, in categories of 5 decreasing detail.
     Debug5 = pg_sys::DEBUG5 as isize,
@@ -60,6 +65,7 @@ impl From<Level> for c_int {
 // TODO: offer a similar interface to that postgres for multi-log lines?
 // TODO: is there a better interface for CStr?
 /// log an error to Postgres
+#[deprecated = "use the new logging macros in pg_extend::log"]
 pub fn log<T1, T2, T3>(level: Level, file: T1, line: u32, func_name: T2, msg: T3) 
 where 
     T1: Into<Vec<u8>>,


### PR DESCRIPTION
Hey, I created this proof of concept. The implementation was trivial this far but there are some open questions:
* ~Any `Error` level log message would get forwarded to PostgreSQL and abort the current query. This might be surprising if the Rust extension uses an external library that logs an error. But given that it's the most serious error level in Rust, I don't think it's that concerning.~
* ~Initialization. Should we define a `_PG_init` to automatically initialize the logger or let the extension author write that boilerplate? In any case, I think `pg_extend` should provide a wrapper to register hooks for initialization. Is there a common hook system for Rust?~
* ~What happens when there are two Rust extensions loaded in a process, it seems they would share the logger instance. `init` would be called per extension, but `set_logger` can only be done once per process. This is less ugly if both use the same lozgger but if the other extension had a different logging implementation, it sounds iffy suddenly.~
* ~This adds a `log` dependency to `pg_extend`, should I split it out into a separate crate instead?~

TODO:
- [x] ~Better system for init hooks~
- [ ] Write documentation
- [x] Example
- [x] Tests
