### PR TITLE
doc(examples) Fix `CREATE FUNCTION` for the `strings` example.

### DIFF
--- a/examples/strings/README.md
+++ b/examples/strings/README.md
@@ -11,5 +11,5 @@ then load into Postgres:
 
 ```console
 $> psql $CONN_STR
-postgres=# CREATE FUNCTION concat_rs(text, text) RETURNS text AS 'path/to/crate/target/release/libstrings.dylib', 'strings' LANGUAGE C STRICT;
+postgres=# CREATE FUNCTION concat_rs(text, text) RETURNS text AS 'path/to/crate/target/release/libstrings.dylib', 'pg_concat_rs' LANGUAGE C STRICT;
 ```


### PR DESCRIPTION
Fix for macOS. It's probably the same for the other examples?