### PR TITLE
WIP:  first stab at making Postgres MemoryContexts easier to use.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/target
 /target
 **/*.rs.bk
+*.iml

--- a/pg-extend/wrapper.h
+++ b/pg-extend/wrapper.h
@@ -24,3 +24,4 @@
 #include "utils/rel.h"
 #include "utils/lsyscache.h"
 #include "utils/palloc.h"
+#include "utils/memutils.h"


### PR DESCRIPTION
Perhaps this might could replace `PgAllocator` given more work.

The idea here was to come up with an API that's a little more natural to working with PG in C, as it relates (at least) to dealing with memory contexts.

In any given function exposed Rust function, it might look something like this:


```rust
{
   let PgMemoryContext cxt = PgMemoryContext::top_transaction().switch_to();  // switches to the TopTransactionContext
   let some_bytes = cxt.alloc(32768);
   some_bytes
   // cxt gets dropped and switches back automatically to whatever the CurrentMemoryContext was
}
```

Alternatively, you could just allocate some PG memory directly in a context:

```rust
{
   let some_bytes = PgMemoryContext::current_transaction().alloc(32768);
   some_bytes
}
```

None of this is related to how Rust allocates memory, of course.  Rusts normal rules for its allocated bytes would apply.  I haven't really yet through through how to reassign ownership of Rust allocated memory to a particular Postgres MemoryContext, but I'm not sure that's even a useful thing -- any memory we want PG to hold on to needs to be allocated by PG anyways.