### PR TITLE
Add support for PostgreSQL 12

### DIFF
--- a/pg-extend/Cargo.toml
+++ b/pg-extend/Cargo.toml
@@ -22,6 +22,7 @@ fdw = []
 postgres-9 = ["fdw"]
 postgres-10 = ["fdw"]
 postgres-11 = []
+postgres-12 = []
 
 [dependencies]
 

--- a/pg-extend/build.rs
+++ b/pg-extend/build.rs
@@ -60,7 +60,7 @@ fn main() {
         .expect("Couldn't write bindings!");
 
     let feature_version = get_postgres_feature_version(pg_include);
-    println!("cargo:rustc-cfg=feature=\"{}\"", feature_version)
+    println!("cargo:rustc-cfg=feature=\"{}\"", feature_version);
 }
 
 fn include_dir() -> Result<String, env::VarError> {
@@ -122,6 +122,7 @@ fn get_postgres_feature_version(pg_include: String) -> &'static str {
         ["9", _] => "postgres-9",
         ["10"] => "postgres-10",
         ["11"] => "postgres-11",
+        ["12"] => "postgres-12",
         val => panic!("unknown Postgres version {:?}", val),
     }
 }

--- a/pg-extend/src/pg_datum.rs
+++ b/pg-extend/src/pg_datum.rs
@@ -35,6 +35,14 @@ impl<'mc> PgDatum<'mc> {
         PgDatum(datum, PhantomData)
     }
 
+    /// Returns a new PgDatum wrapper if you already have Option<Datum>
+    pub unsafe fn from_option(
+        _memory_context: &'mc PgAllocator,
+        datum: Option<Datum>,
+    ) -> PgDatum<'mc> {
+        PgDatum(datum, PhantomData)
+    }
+
     /// Return true if this Datum is None
     ///
     /// # Notes

--- a/pg-extend/src/pg_fdw.rs
+++ b/pg-extend/src/pg_fdw.rs
@@ -8,7 +8,7 @@
 
 // FDW on PostgreSQL 11+ is not supported. :(
 // If anyone tries to enable "fdw" feature with newer Postgres, throw error.
-#[cfg(feature = "postgres-11")]
+#[cfg(any(feature = "postgres-11", feature = "postgres-12"))]
 compile_error!("pg-extend-rs does not support FDW on PostgreSQL 11 or newer. See https://github.com/bluejekyll/pg-extend-rs/issues/49");
 
 use std::boxed::Box;


### PR DESCRIPTION
PostgreSQL 12 brings changes to `FunctionCallInfoData` (the way arguments
are passed to functions) and the FDW API.

This pull request:
* Implements support for the new call interface (keeping backwards compatibility).
* Disables FDW support in PostgreSQL 12.

Upstream commit:
https://github.com/postgres/postgres/commit/a9c35cf85ca1ff72f16f0f10d7ddee6e582b62b8

----

fixes: #95