### PR TITLE
Fix warning "Trait objects without explicit 'dyn' are deprecated"

### DIFF
--- a/examples/fdw-rw/src/lib.rs
+++ b/examples/fdw-rw/src/lib.rs
@@ -62,7 +62,7 @@ impl ForeignRow for MyRow {
 }
 
 impl Iterator for CacheFDW {
-    type Item = Box<ForeignRow>;
+    type Item = Box<dyn ForeignRow>;
     fn next(&mut self) -> Option<Self::Item> {
         match self.inner.pop() {
             None => None,
@@ -103,7 +103,7 @@ CREATE FOREIGN TABLE {schema}.mytable (
         Some(vec!["key".into()])
     }
 
-    fn update(&self, new_row: &Tuple, indices: &Tuple) -> Option<Box<ForeignRow>> {
+    fn update(&self, new_row: &Tuple, indices: &Tuple) -> Option<Box<dyn ForeignRow>> {
         let mut c = get_cache().write().unwrap();
         let key = indices.get("key");
         let value = new_row.get("value");
@@ -126,12 +126,12 @@ CREATE FOREIGN TABLE {schema}.mytable (
         }
     }
 
-    fn insert(&self, new_row: &Tuple) -> Option<Box<ForeignRow>> {
+    fn insert(&self, new_row: &Tuple) -> Option<Box<dyn ForeignRow>> {
         // Since we only use one field from each, these methods are equivalent
         self.update(new_row, new_row)
     }
 
-    fn delete(&self, indices: &Tuple) -> Option<Box<ForeignRow>> {
+    fn delete(&self, indices: &Tuple) -> Option<Box<dyn ForeignRow>> {
         // TODO: switch to correct memory context
         let memory_context = PgAllocator::current_context();
 

--- a/examples/fdw/src/lib.rs
+++ b/examples/fdw/src/lib.rs
@@ -44,7 +44,7 @@ impl ForeignRow for MyRow {
 }
 
 impl Iterator for DefaultFDW {
-    type Item = Box<ForeignRow>;
+    type Item = Box<dyn ForeignRow>;
     fn next(&mut self) -> Option<Self::Item> {
         self.i += 1;
         if self.i > 5 {

--- a/integration-tests/tests/logging.rs
+++ b/integration-tests/tests/logging.rs
@@ -35,7 +35,7 @@ impl MsgCapture {
         mem::replace(&mut *msgs, Vec::new())
     }
     /// Returns a callback for Connection::set_notice_handler()
-    fn get_handler(&self) -> Box<HandleNotice> {
+    fn get_handler(&self) -> Box<dyn HandleNotice> {
         let msgs = self.msgs.clone();
         // HandleNotice trait is implemented for FnMut(DbError)
         return Box::new(move |e: DbError| {

--- a/pg-extend/src/pg_fdw.rs
+++ b/pg-extend/src/pg_fdw.rs
@@ -20,7 +20,7 @@ pub type Tuple<'mc> = HashMap<String, pg_datum::PgDatum<'mc>>;
 /// is responsible for creating row objects to return data.
 /// The object is only active for the lifetime of a query, so it
 /// is not an appropriate place to put caching or long-running connections.
-pub trait ForeignData: Iterator<Item = Box<ForeignRow>> {
+pub trait ForeignData: Iterator<Item = Box<dyn ForeignRow>> {
     /// Called when a scan is initiated. Note that any heavy set up
     /// such as making connections or allocating memory should not
     /// happen in this step, but on the first call to next()
@@ -61,7 +61,7 @@ pub trait ForeignData: Iterator<Item = Box<ForeignRow>> {
     /// specified by index_columns. Do not assume columns present in indices
     /// were present in the UPDATE statement.
     /// Returns the updated row, or None if no update occured.
-    fn update<'mc>(&self, _new_row: &Tuple<'mc>, _indices: &Tuple<'mc>) -> Option<Box<ForeignRow>> {
+    fn update<'mc>(&self, _new_row: &Tuple<'mc>, _indices: &Tuple<'mc>) -> Option<Box<dyn ForeignRow>> {
         error!("Table does not support update");
         None
     }
@@ -69,7 +69,7 @@ pub trait ForeignData: Iterator<Item = Box<ForeignRow>> {
     /// Method for INSERTs. Takes in new_row (which is a mapping of column
     /// names to values). Returns the inserted row, or None if no insert
     /// occurred.
-    fn insert<'mc>(&self, _new_row: &Tuple<'mc>) -> Option<Box<ForeignRow>> {
+    fn insert<'mc>(&self, _new_row: &Tuple<'mc>) -> Option<Box<dyn ForeignRow>> {
         error!("Table does not support insert");
         None
     }
@@ -77,7 +77,7 @@ pub trait ForeignData: Iterator<Item = Box<ForeignRow>> {
     /// Method for DELETEs. Takes in a indices is the same, which consists of columns
     /// specified by index_columns.
     /// Returns the deleted row, or None if no row was deleted.
-    fn delete<'mc>(&self, _indices: &Tuple<'mc>) -> Option<Box<ForeignRow>> {
+    fn delete<'mc>(&self, _indices: &Tuple<'mc>) -> Option<Box<dyn ForeignRow>> {
         error!("Table does not support delete");
         None
     }
@@ -222,7 +222,7 @@ impl<T: ForeignData> ForeignWrapper<T> {
     fn get_field<'mc>(
         _memory_context: &'mc PgAllocator,
         attr: &pg_sys::FormData_pg_attribute,
-        row: &'mc ForeignRow,
+        row: &'mc dyn ForeignRow,
     ) -> Result<Option<pg_datum::PgDatum<'mc>>, String> {
         let name = Self::name_to_string(attr.attname);
         // let typ = attr.atttypid;


### PR DESCRIPTION
'dyn Trait' syntax was introduced in Rust 1.27 and deprecation begun in
recent Rust versions.