### PR TITLE
Disable FDW support on Postgres 11+ (see #49); created new feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,22 +460,6 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "fdw"
-version = "0.1.0"
-dependencies = [
- "pg-extend 0.2.1",
- "pg-extern-attr 0.2.2",
-]
-
-[[package]]
-name = "fdw-rw"
-version = "0.1.0"
-dependencies = [
- "pg-extend 0.2.1",
- "pg-extern-attr 0.2.2",
-]
-
-[[package]]
 name = "filetime"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,11 @@ debug = true
 members = [
     "pg-extend", 
     "pg-extern-attr", 
-    "examples/adding", 
-    "examples/fdw",
-    "examples/fdw-rw",
+    "examples/adding",
+# Examples disabled because FDW support broken with PostgreSQL 11+.
+# See https://github.com/bluejekyll/pg-extend-rs/issues/49
+#    "examples/fdw",
+#    "examples/fdw-rw",
     "examples/logging",
     "examples/memory_context",
     "examples/nullable",

--- a/examples/fdw-rw/Cargo.toml
+++ b/examples/fdw-rw/Cargo.toml
@@ -9,4 +9,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pg-extern-attr = { version = "*", path = "../../pg-extern-attr" }
-pg-extend = { version = "*", path = "../../pg-extend" }
+pg-extend = { version = "*", path = "../../pg-extend", features = ["fdw"] }

--- a/examples/fdw/Cargo.toml
+++ b/examples/fdw/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/bin.rs"
 
 [dependencies]
 pg-extern-attr = { version = "*", path = "../../pg-extern-attr" }
-pg-extend = { version = "*", path = "../../pg-extend" }
+pg-extend = { version = "*", path = "../../pg-extend", features = ["fdw"] }

--- a/integration-tests/tests/fdw.rs
+++ b/integration-tests/tests/fdw.rs
@@ -5,6 +5,10 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+// FDW tests disabled because it's broken with PostgreSQL 11+.
+// See See https://github.com/bluejekyll/pg-extend-rs/issues/49
+#![cfg(fdw_is_broken)]
+
 extern crate integration_tests;
 
 use integration_tests::*;

--- a/pg-extend/Cargo.toml
+++ b/pg-extend/Cargo.toml
@@ -17,9 +17,10 @@ license = "MIT/Apache-2.0"
 build = "build.rs"
 
 [features]
-default = ["postgres-10"]
-postgres-9 = []
-postgres-10 = []
+default = []
+fdw = []
+postgres-9 = ["fdw"]
+postgres-10 = ["fdw"]
 postgres-11 = []
 
 [dependencies]

--- a/pg-extend/src/pg_fdw.rs
+++ b/pg-extend/src/pg_fdw.rs
@@ -4,6 +4,13 @@
 //! and https://bitbucket.org/adunstan/rotfang-fdw/src/ca21c2a2e5fa6e1424b61bf0170adb3ab4ae68e7/src/rotfang_fdw.c?at=master&fileviewer=file-view-default
 //! For use with `#[pg_foreignwrapper]` from pg-extend-attr
 
+#![cfg(feature = "fdw")]
+
+// FDW on PostgreSQL 11+ is not supported. :(
+// If anyone tries to enable "fdw" feature with newer Postgres, throw error.
+#[cfg(feature = "postgres-11")]
+compile_error!("pg-extend-rs does not support FDW on PostgreSQL 11 or newer. See https://github.com/bluejekyll/pg-extend-rs/issues/49");
+
 use std::boxed::Box;
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};


### PR DESCRIPTION
Unfortunately, FDW examples and tests have to be disabled entirely,
because 'examples/fdw' cannot depend on 'pg-extend' crate features.

This is a prerequisite to #86.
