### PR TITLE
Use correct data type in Unix for siglongjmp

### DIFF
--- a/pg-extend/src/lib.rs
+++ b/pg-extend/src/lib.rs
@@ -142,7 +142,7 @@ unsafe fn pg_sys_longjmp(_buf: *mut pg_sys::_JBTYPE, _value: ::std::os::raw::c_i
 }
 
 #[cfg(unix)]
-unsafe fn pg_sys_longjmp(_buf: *mut pg_sys::_JBTYPE, _value: ::std::os::raw::c_int) {
+unsafe fn pg_sys_longjmp(_buf: *mut pg_sys::__jmp_buf_tag, _value: ::std::os::raw::c_int) {
     pg_sys::siglongjmp(_buf, _value);
 }
 


### PR DESCRIPTION
While attempting to build a Linux-based extension with the latest revision, it failed as the `_JBTYPE` type didn't exist. PG has different naming in some types and functions between POSIX and Windows. I missed this having different naming when pushed the PR for Windows support. After changing this, building a FDW for PG10 in Linux compiles successfully.