### PR TITLE
Set some libpq environment variables for development

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -30,6 +30,10 @@ ALL_FEATURES = "--all-features"
 # Defaults are all for postgres version 12
 PG_VERSION = { source = "${CARGO_MAKE_PROFILE}", default_value = "12.1", mapping = { v10 = "10.11", v11 = "11.6" }}
 PG_PORT = { source = "${CARGO_MAKE_PROFILE}", default_value = "5444", mapping = { v10 = "5442", v11 = "5443" }}
+PGSERVICE = { unset = true }
+PGHOST = "/tmp/"
+PGDATABASE = "postgres"
+PSQLRC = "/dev/null" # This ensures that every psql invocation will skip the user's .psqlrc file"
 VER_FEATURES = { source = "${CARGO_MAKE_PROFILE}", default_value = "--features=postgres-12", mapping = { v10 = "--features=postgres-10", v11 = "--features=postgres-11" }}
 
 PG_DIR = "${TARGET_DIR}/postgres"

--- a/integration-tests/postgresql.conf
+++ b/integration-tests/postgresql.conf
@@ -63,7 +63,7 @@
 #port = 5442				# (change requires restart)
 max_connections = 100			# (change requires restart)
 #superuser_reserved_connections = 3	# (change requires restart)
-#unix_socket_directories = '/tmp'	# comma-separated list of directories
+unix_socket_directories = '/tmp'	# comma-separated list of directories
 					# (change requires restart)
 #unix_socket_group = ''			# (change requires restart)
 #unix_socket_permissions = 0777		# begin with 0 to use octal notation


### PR DESCRIPTION
Some environments (like mine) have many PostgreSQL variables set and I
ran into some issues to run the make examples.

By explicitly setting some environment variables, we ensure the build
instructions will work on more environments.