### PR TITLE
draft; add bytea support

### DIFF
--- a/pg-extend/src/native/bytea.rs
+++ b/pg-extend/src/native/bytea.rs
@@ -1,0 +1,46 @@
+use std::ops::Deref;
+use std::ptr::NonNull;
+
+use crate::native::VarLenA;
+use crate::pg_alloc::{PgAllocated, PgAllocator};
+use crate::pg_sys;
+
+/// A zero-overhead view of `bytea` data from Postgres
+pub struct ByteA<'mc>(PgAllocated<'mc, NonNull<pg_sys::bytea>>);
+
+// :consider would be good to make a derive(FromVarLenA) macro.
+impl<'mc> ByteA<'mc> {
+    /// Create from the raw pointer to the Postgres data
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe fn from_raw(alloc: &'mc PgAllocator, raw_ptr: *mut pg_sys::bytea) -> Self {
+        ByteA(PgAllocated::from_raw(alloc, raw_ptr))
+    }
+
+    /// Convert into the underlying pointer
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe fn into_ptr(mut self) -> *mut pg_sys::bytea {
+        self.0.take_ptr()
+    }
+
+    /// Return true if this is empty
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Return the length of the bytea data
+    pub fn len(&self) -> usize {
+        let varlena = unsafe { VarLenA::from_varlena(self.0.as_ref()) };
+        varlena.len()
+    }
+}
+
+impl<'mc> Deref for ByteA<'mc> {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        unsafe {
+            let varlena = VarLenA::from_varlena(self.0.as_ref());
+            &*(varlena.as_slice() as *const [i8] as *const [u8])
+        }
+    }
+}

--- a/pg-extend/src/native/mod.rs
+++ b/pg-extend/src/native/mod.rs
@@ -9,8 +9,10 @@
 //!
 //! These shoudl be near zero overhead types, exposed from Postgres and able to be directly used.
 
+mod bytea;
 mod text;
 mod varlena;
 
+pub use bytea::ByteA;
 pub use text::Text;
 pub(crate) use varlena::VarLenA;

--- a/pg-extend/src/pg_alloc.rs
+++ b/pg-extend/src/pg_alloc.rs
@@ -203,6 +203,9 @@ impl RawPtr for std::ffi::CString {
     }
 }
 
+// FIXME
+// `pg_sys::text` aliases `varlena`. This impl covers all `varlena` types, including `bytea`.
+// Given that `Target` is an associated type, we are stuck with `pg_sys::text` for everything.
 impl RawPtr for NonNull<pg_sys::text> {
     type Target = pg_sys::text;
 

--- a/pg-extend/src/pg_type.rs
+++ b/pg-extend/src/pg_type.rs
@@ -1,6 +1,6 @@
 //! Postgres type definitions
 
-use crate::native::Text;
+use crate::native::{ByteA, Text};
 
 /// See https://www.postgresql.org/docs/11/xfunc-c.html#XFUNC-C-TYPE-TABLE
 ///
@@ -217,6 +217,24 @@ impl PgTypeInfo for i32 {
 impl PgTypeInfo for i64 {
     fn pg_type() -> PgType {
         PgType::Int8
+    }
+}
+
+impl PgTypeInfo for Vec<u8> {
+    fn pg_type() -> PgType {
+        PgType::ByteA
+    }
+}
+
+impl PgTypeInfo for &[u8] {
+    fn pg_type() -> PgType {
+        PgType::ByteA
+    }
+}
+
+impl PgTypeInfo for ByteA<'_> {
+    fn pg_type() -> PgType {
+        PgType::ByteA
     }
 }
 


### PR DESCRIPTION
Adds support for `bytea`.

This PR is rough. I mostly ripped off the implementation for `Text` where possible.

There's a lot of `unsafe` in here that I'm not sure I'm respecting the invariants of. I also don't understand the current state of allocation in the codebase (should I `palloc` or `MemoryContextAlloc`?). 

If anyone has time to explain to me the Right Way to do things, I am happy to do a rewrite. Otherwise, hopefully someone can use this as stub code.