### PR TITLE
Meta: Re-enable windows tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        #os: [ubuntu-latest, macos-latest, windows-latest]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        #os: [ubuntu-latest, macos-latest]
         version: ["v10", "v11", "v12"]
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,8 +52,8 @@ jobs:
     needs: postgres
     strategy:
       matrix:
-        #os: [ubuntu-latest, macos-latest, windows-latest]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        #os: [ubuntu-latest, macos-latest]
         feature: [no-default-features, default-features, all-features]
         version: ["v10", "v11", "v12"]
     steps:


### PR DESCRIPTION
With the help of @bluejekyll I have successfully build a postgres pg-extend-rs extension for x64-windows-msvc. Since almost no changes were needed (other than a lot of tools). We will try to re-enable windows tests