### PR TITLE
Fix github issue #49

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,14 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "fdw"
+version = "0.1.0"
+dependencies = [
+ "pg-extend 0.2.1",
+ "pg-extern-attr 0.2.2",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
     "examples/adding",
 # Examples disabled because FDW support broken with PostgreSQL 11+.
 # See https://github.com/bluejekyll/pg-extend-rs/issues/49
-#    "examples/fdw",
+    "examples/fdw",
 #    "examples/fdw-rw",
     "examples/logging",
     "examples/memory_context",

--- a/examples/fdw/src/lib.rs
+++ b/examples/fdw/src/lib.rs
@@ -8,7 +8,7 @@
 extern crate pg_extend;
 extern crate pg_extern_attr;
 
-use pg_extend::pg_fdw::{ForeignData, ForeignRow, OptionMap, ForeignTableMetadata};
+use pg_extend::pg_fdw::{ForeignData, ForeignRow, ForeignTableMetadata, OptionMap};
 use pg_extend::{pg_datum, pg_magic, pg_type};
 use pg_extern_attr::pg_foreignwrapper;
 

--- a/integration-tests/tests/fdw.rs
+++ b/integration-tests/tests/fdw.rs
@@ -11,7 +11,6 @@ use integration_tests::*;
 // FDW tests disabled because it's broken with PostgreSQL 11+.
 // See See https://github.com/bluejekyll/pg-extend-rs/issues/49
 #[test]
-#[ignore] // this test is currently broken
 fn test_fdw() {
     test_in_db("fdw", |mut conn| {
         conn.batch_execute(

--- a/pg-extend/src/pg_fdw.rs
+++ b/pg-extend/src/pg_fdw.rs
@@ -333,7 +333,7 @@ impl<T: ForeignData> ForeignWrapper<T> {
     
 
     /// Retrieve next row from the result set, or clear tuple slot to indicate
-    ///	EOF.
+    /// EOF.
     /// Fetch one row from the foreign
     ///  (the node's ScanTupleSlot should be used for this purpose).
     ///  Return NULL if no more rows are available.

--- a/pg-extend/src/pg_fdw.rs
+++ b/pg-extend/src/pg_fdw.rs
@@ -313,24 +313,20 @@ impl<T: ForeignData> ForeignWrapper<T> {
 
         t
     }
- 
+
     unsafe fn tupdesc_attrs(tupledesc: &pg_sys::tupleDesc) -> &[pg_sys::FormData_pg_attribute] {
-        
         #[cfg(feature = "postgres-11")]
         #[allow(clippy::cast_ptr_alignment)]
         {
-            let attrs  = (*tupledesc).attrs.as_ptr();
-            std::slice::from_raw_parts(attrs, (*tupledesc).natts as usize)    
+            let attrs = (*tupledesc).attrs.as_ptr();
+            std::slice::from_raw_parts(attrs, (*tupledesc).natts as usize)
         }
         #[cfg(not(feature = "postgres-11"))]
         {
             let attrs = (*tupledesc).attrs;
             std::slice::from_raw_parts(*attrs, (*tupledesc).natts as usize)
         }
-        
-
     }
-    
 
     /// Retrieve next row from the result set, or clear tuple slot to indicate
     /// EOF.


### PR DESCRIPTION
pg_fdw was not working with PG11 because the layout
of TupleDesc has changed.  Return an array of
FormData_pg_attribute instead of an array of
points to them.

----

fixes: #49 