### PR TITLE
Disable the FDW tests on postgres-12.

### DIFF
--- a/examples/fdw/src/bin.rs
+++ b/examples/fdw/src/bin.rs
@@ -4,9 +4,12 @@
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
-
+#[cfg(feature = "fdw")]
 extern crate pg_extend;
-
+#[cfg(feature = "fdw")]
 use pg_extend::pg_create_stmt_bin;
-
+#[cfg(feature = "fdw")]
 pg_create_stmt_bin!(DefaultFDW_pg_create_stmt);
+
+#[cfg(not(feature = "fdw"))]
+fn main() {}

--- a/examples/fdw/src/lib.rs
+++ b/examples/fdw/src/lib.rs
@@ -4,7 +4,7 @@
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
-
+#![cfg(feature = "fdw")]
 extern crate pg_extend;
 extern crate pg_extern_attr;
 

--- a/integration-tests/tests/fdw.rs
+++ b/integration-tests/tests/fdw.rs
@@ -8,9 +8,8 @@ extern crate integration_tests;
 
 use integration_tests::*;
 
-// FDW tests disabled because it's broken with PostgreSQL 11+.
-// See See https://github.com/bluejekyll/pg-extend-rs/issues/49
 #[test]
+#[cfg(feature = "fdw")]
 fn test_fdw() {
     test_in_db("fdw", |mut conn| {
         conn.batch_execute(


### PR DESCRIPTION
The FDW module is not compiled with postgres-12.